### PR TITLE
Flpsc

### DIFF
--- a/threeML/catalogs/Fermi.py
+++ b/threeML/catalogs/Fermi.py
@@ -462,6 +462,7 @@ threefgl_types = {
     'snr': 'supernova remnant',
     'spp': 'special case - potential association with SNR or PWN',
     'ssrq': 'soft spectrum radio quasar',
+    'unk':'unknown',
     '': 'unknown'
 }
 
@@ -641,12 +642,12 @@ class FermiLATSourceCatalog(VirtualObservatoryCatalog):
         return answer
 
     def apply_format(self, table):
-
         def translate(key):
             if (key.lower() == 'psr'):
                 return threefgl_types[key]
-            else:
-                return threefgl_types[key.lower()]
+            if key.lower() in threefgl_types.keys():
+                return threefgl_types[key.lower()]            
+            return 'unknown'
 
         # Translate the 3 letter code to a more informative category, according
         # to the dictionary above
@@ -658,7 +659,7 @@ class FermiLATSourceCatalog(VirtualObservatoryCatalog):
             new_table = table['name',
                               'source_type',
                               'ra', 'dec',
-                              'assoc_name_1',
+                              'assoc_name',
                               'tevcat_assoc',
                               'Search_Offset']
 
@@ -672,7 +673,7 @@ class FermiLATSourceCatalog(VirtualObservatoryCatalog):
             new_table = table['name',
                               'source_type',
                               'ra', 'dec',
-                              'assoc_name_1',
+                              'assoc_name',
                               'tevcat_assoc']
 
             return new_table.group_by('name')


### PR DESCRIPTION
The new 4FGL catalog has some differences in format from the 3FGL, in particulars the names of the parameters of the models, and the "tvecat_assoc" column. This caused the code in Fermi.py to crash. The changes I have implemented are NOT backward compatible, but the VO interface to the fermi catalog automatically retrieve the 4FGL, so there is no way to use the 3FGL catalog, which is, by all means, superseded by the 4FGL.