### PR TITLE
add transformation for 1D contours

### DIFF
--- a/threeML/minimizer/minimization.py
+++ b/threeML/minimizer/minimization.py
@@ -223,6 +223,11 @@ class ProfileLikelihood(object):
 
             assert len(self._fixed_parameters) == 1, "You cannot step in 1d if you fix 2 parameters"
 
+            param_1_name = self._fixed_parameters[0]
+
+            # Fix steps if needed
+            steps1 = self._transform_steps(param_1_name, steps1)
+
             return self._step1d(steps1)
 
     def __call__(self, values):

--- a/threeML/minimizer/minimization.py
+++ b/threeML/minimizer/minimization.py
@@ -225,7 +225,7 @@ class ProfileLikelihood(object):
 
             param_1_name = self._fixed_parameters[0]
 
-            # Fix steps if needed
+            # Fix steps if needed.
             steps1 = self._transform_steps(param_1_name, steps1)
 
             return self._step1d(steps1)


### PR DESCRIPTION
Parameter transformations were ignored for 1D likelihood contours. This pull request adds the parameter transform in the correct place and lets us produce 1D likelihood contours for parameters with internal transformations.

(2D likelihood contours had the transformations applied already).

Script & datapoints to test contour plots: [example.tar.gz](https://github.com/threeML/threeML/files/3099573/example.tar.gz)
