### PR TITLE
Update tests and Fermi catalog to work with the latest version (19) o…

### DIFF
--- a/threeML/catalogs/Fermi.py
+++ b/threeML/catalogs/Fermi.py
@@ -530,8 +530,10 @@ def _get_point_source_from_3fgl(fgl_name, catalog_entry, fix=False):
         this_spectrum.xc = float(catalog_entry['cutoff']) * u.MeV
         this_spectrum.xc.fix = fix
 
-    elif spectrum_type == 'PLSuperExpCutoff2':
+    elif spectrum_type in ['PLSuperExpCutoff', 'PLSuperExpCutoff2']:
         # This is the new definition, from the 4FGL catalog.
+        # Note that in version 19 of the 4FGL, cutoff spectra are designated as PLSuperExpCutoff
+        # rather than PLSuperExpCutoff2 as in version , but the same parametrization is used.
         this_spectrum = Super_cutoff_powerlaw()
 
         this_source = PointSource(name, ra=ra, dec=dec, spectral_shape=this_spectrum)
@@ -552,7 +554,7 @@ def _get_point_source_from_3fgl(fgl_name, catalog_entry, fix=False):
 
     else:
 
-        raise NotImplementedError("Spectrum type %s is not a valid 3FGL type" % spectrum_type)
+        raise NotImplementedError("Spectrum type %s is not a valid 4FGL type" % spectrum_type)
 
     return this_source
 

--- a/threeML/test/test_FermipyLike.py
+++ b/threeML/test/test_FermipyLike.py
@@ -30,7 +30,7 @@ def test_FermipyLike():
 
     model = lat_catalog.get_model()
 
-    assert model.get_number_of_point_sources() == 90
+    assert model.get_number_of_point_sources() == 133
 
     # Let's free all the normalizations within 3 deg from the center
     model.free_point_sources_within_radius(3.0, normalization_only=True)
@@ -40,13 +40,13 @@ def test_FermipyLike():
     # but then let's fix the sync and the IC components of the Crab
     # (cannot fit them with just one day of data)
     # (these two methods are equivalent)
-    model['Crab_IC.spectrum.main.Powerlaw.K'].fix = True
-    model.Crab_synch.spectrum.main.Powerlaw.K.fix = True
+    model['Crab_IC.spectrum.main.Log_parabola.K'].fix = True
+    model.Crab_synch.spectrum.main.shape.K.fix = True
 
     assert len(model.free_parameters) == 3
 
     # However, let's free the index of the Crab
-    model.PSR_J0534p2200.spectrum.main.Cutoff_powerlaw.index.free = True
+    model.PSR_J0534p2200.spectrum.main.Super_cutoff_powerlaw.index.free = True
 
     assert len(model.free_parameters) == 4
 


### PR DESCRIPTION
…f the 4FGL.

Changes:
* Accept cutoff spectra designated as `PLSuperExpCutoff` (in addition to `PLSuperExpCutoff2`)
* Update unit tests of the fermipy plugin to reflect updates to the Crab spectrum and to the number of sources in the region.

Addresses https://github.com/threeML/threeML/issues/337 and https://github.com/threeML/threeML/issues/332 