### PR TITLE
rm pagmo req for pip

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
         	 pandas
         	 requests
         	 speclite
-        	 pygmo>=2.4,<=2.11.
+#        	 pygmo>=2.4,<=2.11.
         	 ipython
         	 ipyparallel
                  numexpr


### PR DESCRIPTION
needed to remove pygmo from the pip install as it will cause a failure