### PR TITLE
fix loading of background when file is empty string

### DIFF
--- a/threeML/utils/spectrum/pha_spectrum.py
+++ b/threeML/utils/spectrum/pha_spectrum.py
@@ -752,7 +752,13 @@ p
         :return: a path to a file, or None
         """
 
-        return self._return_file('backfile')
+        back_file = self._return_file('backfile')
+
+        if back_file == "":
+            back_file = None
+        
+        
+        return back_file
 
     @property
     def scale_factor(self):


### PR DESCRIPTION
if backfile existed but was empty, it crashed OGIP. This fixes that. 