### PR TITLE
Fix download lat data

### DIFF
--- a/threeML/test/test_download_LAT_data.py
+++ b/threeML/test/test_download_LAT_data.py
@@ -10,9 +10,28 @@ skip_if_internet_is_not_available = pytest.mark.skipif(
     not internet_connection_is_active(), reason="No active internet connection"
 )
 
+try:
+
+    import GtApp
+
+except ImportError:
+
+    has_Fermi = False
+
+else:
+
+    has_Fermi = True
+
+# This defines a decorator which can be applied to single tests to
+# skip them if the condition is not met
+skip_if_LAT_is_not_available = pytest.mark.skipif(not has_Fermi,
+    reason="Fermi Science Tools not installed",
+)
+
 
 @skip_if_internet_is_not_available
 @pytest.mark.xfail
+@skip_if_LAT_is_not_available
 def test_download_LAT_data():
     # Crab
     ra = 83.6331

--- a/threeML/utils/data_download/Fermi_LAT/download_LAT_data.py
+++ b/threeML/utils/data_download/Fermi_LAT/download_LAT_data.py
@@ -74,11 +74,13 @@ class DivParser(html.parser.HTMLParser):
 # Keyword name to store the unique ID for the download
 _uid_fits_keyword = "QUERYUID"
 
-def merge_LAT_data(ft1s,destination_directory=".", outfile  = 'ft1_merged.fits'):
+def merge_LAT_data(ft1s, destination_directory=".", outfile='ft1_merged.fits'):
+
+    if len(ft1s) == 1:
+        print('Only one FT1 file provided. Skipping the merge...')
+        return ft1s[0]
 
     _filelist = "_filelist.txt"
-
-
 
     infile = os.path.join(destination_directory, _filelist)
 
@@ -248,7 +250,7 @@ def download_LAT_data(
             % (prev_downloaded_ft1s, prev_downloaded_ft2)
         )
 
-        return [merge_LAT_data(prev_downloaded_ft1s,destination_directory,outfile='L%s_FT1.fits' % query_unique_id), prev_downloaded_ft2]
+        return merge_LAT_data(prev_downloaded_ft1s, destination_directory, outfile='L%s_FT1.fits' % query_unique_id), prev_downloaded_ft2
 
     # Print them out
 
@@ -470,8 +472,7 @@ def download_LAT_data(
 
             FT1.append(fits_file)
 
-
     # If FT2 is first, switch them, otherwise do nothing
     #if re.match(".+SC[0-9][0-9].fits", downloaded_files[0]) is not None:
 
-    return merge_LAT_data(FT1, destination_directory,outfile='L%s_FT1.fits' % query_unique_id) , FT2
+    return merge_LAT_data(FT1, destination_directory, outfile='L%s_FT1.fits' % query_unique_id), FT2

--- a/threeML/utils/data_download/Fermi_LAT/download_LAT_data.py
+++ b/threeML/utils/data_download/Fermi_LAT/download_LAT_data.py
@@ -453,8 +453,8 @@ def download_LAT_data(
 
     # Separate the FT1 and FT2 files:
 
-    FT1=[]
-    FT2=None
+    FT1 = []
+    FT2 = None
 
     for fits_file in downloaded_files:
         # Open the FITS file and write the unique key for this query, so that the download will not be

--- a/threeML/utils/data_download/Fermi_LAT/download_LAT_data.py
+++ b/threeML/utils/data_download/Fermi_LAT/download_LAT_data.py
@@ -76,15 +76,8 @@ _uid_fits_keyword = "QUERYUID"
 
 def merge_LAT_data(ft1s, destination_directory=".", outfile='ft1_merged.fits'):
 
-    if len(ft1s) == 1:
-        print('Only one FT1 file provided. Skipping the merge...')
-        return ft1s[0]
-
-    _filelist = "_filelist.txt"
-
-    infile = os.path.join(destination_directory, _filelist)
-
     outfile = os.path.join(destination_directory, outfile)
+
     if os.path.exists(outfile):
         print(
             "Existing merged event file %s correspond to the same selection. "
@@ -93,6 +86,17 @@ def merge_LAT_data(ft1s, destination_directory=".", outfile='ft1_merged.fits'):
             % (outfile)
         )
         return outfile
+
+    if len(ft1s) == 1:
+        print('Only one FT1 file provided. Skipping the merge...')
+        import shutil
+        shutil.copyfile(ft1s[0],outfile)
+        return outfile
+
+    _filelist = "_filelist.txt"
+
+    infile = os.path.join(destination_directory, _filelist)
+
 
     infile_list = open(infile,'w')
 

--- a/threeML/utils/data_download/Fermi_LAT/download_LAT_data.py
+++ b/threeML/utils/data_download/Fermi_LAT/download_LAT_data.py
@@ -18,8 +18,6 @@ from threeML.config.config import threeML_config
 from threeML.utils.unique_deterministic_tag import get_unique_deterministic_tag
 from threeML.io.download_from_http import ApacheDirectory
 
-from GtApp import GtApp
-
 # Set default timeout for operations
 socket.setdefaulttimeout(120)
 
@@ -99,6 +97,8 @@ def merge_LAT_data(ft1s,destination_directory=".", outfile  = 'ft1_merged.fits')
     for ft1 in ft1s: infile_list.write(ft1 + '\n' )
 
     infile_list.close()
+
+    from GtApp import GtApp
 
     gtselect = GtApp('gtselect')
 


### PR DESCRIPTION
When the user asks for several LAT data (1 year or more) the server returns several FT1 files and 1 FT2 file. This PR makes sure that all the FT1 files are merged into one big FT1 file. (Before, only the first FT1 file was returned!)
This address the #356 issue
To test, you can either modify the "test_download_LAT_data.py" setting   tstop = "2011-01-02 00:00:00" instead off     tstop = "2010-01-02 00:00:00" and run the test with pytest, or you can simply run this script:

`
#!/usr/bin/env python
from threeML import *
def test_download_LAT_data():
    # Crab
    ra = 83.6331
    dec = 22.0199
    tstart = "2010-01-01 00:00:00"
    #tstop = "2010-01-01 00:00:00" # This downloads 1 file
    tstop = "2011-01-01 00:00:00"  # This will get multiple files

    temp_dir = "_download_temp"

    ft1, ft2 = download_LAT_data(
        ra,
        dec,
        20.0,
        tstart,
        tstop,
        time_type="Gregorian",
        destination_directory=temp_dir,
    )
    return ft1, ft2
ft1,ft2=test_download_LAT_data()
print(ft1)
print(ft2)
`