### PR TITLE
Root minimizer

### DIFF
--- a/threeML/minimizer/ROOT_minimizer.py
+++ b/threeML/minimizer/ROOT_minimizer.py
@@ -2,6 +2,7 @@ from builtins import zip
 from builtins import range
 import ROOT
 import numpy as np
+import ctypes
 
 from threeML.minimizer.minimization import (
     LocalMinimizer,
@@ -209,12 +210,12 @@ class ROOTMinimizer(LocalMinimizer):
 
         for i, par_name in enumerate(self.parameters):
 
-            err_low = ROOT.Double(0)
-            err_up = ROOT.Double(0)
+            err_low = ctypes.c_double(0)
+            err_up = ctypes.c_double(0)
 
             self.minimizer.GetMinosError(i, err_low, err_up)
 
-            errors[par_name] = (err_low, err_up)
+            errors[par_name] = (err_low.value, err_up.value)
 
         return errors
 

--- a/threeML/test/test__minimizers.py
+++ b/threeML/test/test__minimizers.py
@@ -57,6 +57,10 @@ def do_analysis(jl, minimizer):
 
     check_results(fit_results)
 
+    fit_results = jl.get_errors()
+
+    check_results(fit_results)
+    
 
 def test_minuit_simple(joint_likelihood_bn090217206_nai):
 


### PR DESCRIPTION
Fixes https://github.com/threeML/threeML/issues/387

I added a call to `get_errors` to `test__minimizers.py` as well, as the problme did not trip any unit tests previously. 