### PR TITLE
Fix to support fermipy 1.0.0.

### DIFF
--- a/threeML/plugins/FermipyLike.py
+++ b/threeML/plugins/FermipyLike.py
@@ -4,6 +4,7 @@ import astromodels
 import numpy as np
 import os
 import yaml
+import astropy.io.fits as fits
 
 from threeML.exceptions.custom_exceptions import custom_warnings
 from threeML.io.file_utils import sanitize_filename
@@ -389,6 +390,13 @@ class FermipyLike(PluginPrototype):
         )
 
         basic_config["selection"]["zmax"] = zmax
+
+        with fits.open(scfile) as ft2_:
+            tmin = float(ft2_[0].header["TSTART"])
+            tmax = float(ft2_[0].header["TSTOP"])
+        
+        basic_config["selection"]["tmin"] = tmin
+        basic_config["selection"]["tmax"] = tmax
 
         evclass = int(evclass)
         assert is_power_of_2(evclass), "The provided evclass is not a power of 2."

--- a/threeML/test/test_FermipyLike.py
+++ b/threeML/test/test_FermipyLike.py
@@ -32,7 +32,7 @@ def test_FermipyLike():
 
     model = lat_catalog.get_model()
 
-    assert model.get_number_of_point_sources() == 133
+    assert model.get_number_of_point_sources() == 147
 
     # Let's free all the normalizations within 3 deg from the center
     model.free_point_sources_within_radius(3.0, normalization_only=True)


### PR DESCRIPTION
This pull request implements the fix to support the new version of `fermipy` (issue #385). Unfortunately the plugin is still not working because of a couple of issues on the fermipy side. For reference these are the related issues that have to be solved:
- https://github.com/fermiPy/fermipy/issues/369
- https://github.com/fermiPy/fermipy/issues/372