### PR TITLE
New features

### DIFF
--- a/threeML/bayesian/bayesian_analysis.py
+++ b/threeML/bayesian/bayesian_analysis.py
@@ -12,6 +12,8 @@ from threeML.bayesian.ultranest_sampler import UltraNestSampler
 from threeML.bayesian.dynesty_sampler import DynestyNestedSampler, DynestyDynamicSampler
 #from threeML.bayesian.pinnuts_sampler import NUTSSampler
 from astromodels import ModelAssertionViolation, use_astromodels_memoization
+from threeML.data_list import DataList
+from astromodels.core.model import Model
 
 _available_samplers = {}
 _available_samplers["multinest"] = MultiNestSampler
@@ -24,7 +26,7 @@ _available_samplers["dynesty_dynamic"] = DynestyDynamicSampler
 
 
 class BayesianAnalysis(object):
-    def __init__(self, likelihood_model, data_list, **kwargs):
+    def __init__(self, likelihood_model: Model, data_list: DataList, **kwargs):
         """
         Bayesian analysis.
 
@@ -61,7 +63,7 @@ class BayesianAnalysis(object):
 
 
         
-    def _register_model_and_data(self, likelihood_model, data_list):
+    def _register_model_and_data(self, likelihood_model: Model, data_list: DataList):
         """
 
         make sure the model and data list are set up
@@ -113,15 +115,20 @@ class BayesianAnalysis(object):
 
 
         
-    def set_sampler(self, sampler_name):
-
+    def set_sampler(self, sampler_name: str, **kwargs):
+        """
+        Set the sampler
+        :param sampler_name: (str) Name of sampler
+        :param share_spectrum: (optional) Option to share the spectrum calc
+        between detectors with the same input energy bins
+        """
         assert sampler_name in _available_samplers, (
             "%s is not a valid sampler please choose from %s"
             % (sampler_name, ",".join(list(_available_samplers.keys())))
         )
 
         self._sampler = _available_samplers[sampler_name](
-            self._likelihood_model, self._data_list
+            self._likelihood_model, self._data_list, **kwargs
         )
 
     @property

--- a/threeML/bayesian/multinest_sampler.py
+++ b/threeML/bayesian/multinest_sampler.py
@@ -1,5 +1,6 @@
 import os
 import time
+from typing import Optional
 
 import numpy as np
 
@@ -7,6 +8,8 @@ import numpy as np
 from threeML.bayesian.sampler_base import UnitCubeSampler
 from threeML.config.config import threeML_config
 from astromodels import ModelAssertionViolation, use_astromodels_memoization
+from threeML.data_list import DataList
+from astromodels.core.model import Model
 
 try:
 
@@ -42,7 +45,10 @@ except:
 
 
 class MultiNestSampler(UnitCubeSampler):
-    def __init__(self, likelihood_model=None, data_list=None, **kwargs):
+    def __init__(self,
+                 likelihood_model: Optional[Model]=None,
+                 data_list: Optional[DataList]=None,
+                 **kwargs):
         """
         Implements the MultiNest sampler of https://github.com/farhanferoz/MultiNest
         via the python wrapper of https://github.com/JohannesBuchner/PyMultiNest
@@ -60,10 +66,10 @@ class MultiNestSampler(UnitCubeSampler):
 
     def setup(
         self,
-        n_live_points,
-        chain_name="chains/fit-",
-        resume=False,
-        importance_nested_sampling=False,
+        n_live_points: int,
+        chain_name: str="chains/fit-",
+        resume: bool=False,
+        importance_nested_sampling: bool=False,
         **kwargs
     ):
         """
@@ -91,7 +97,7 @@ class MultiNestSampler(UnitCubeSampler):
 
         self._is_setup = True
 
-    def sample(self, quiet=False):
+    def sample(self, quiet: bool=False):
         """
         sample using the MultiNest numerical integration method
 

--- a/threeML/bayesian/sampler_base.py
+++ b/threeML/bayesian/sampler_base.py
@@ -29,10 +29,13 @@ from threeML.analysis_results import BayesianResults
 from threeML.utils.statistics.stats_tools import aic, bic, dic
 from threeML.exceptions.custom_exceptions import LikelihoodIsInfinite, custom_warnings
 from astromodels.functions.function import ModelAssertionViolation
-
+from threeML.plugins.SpectrumLike import SpectrumLike
+from threeML.plugins.DispersionSpectrumLike import DispersionSpectrumLike
+from threeML.data_list import DataList
+from astromodels.core.model import Model
 
 class SamplerBase(with_metaclass(abc.ABCMeta, object)):
-    def __init__(self, likelihood_model, data_list, **kwargs):
+    def __init__(self, likelihood_model : Model, data_list : DataList, **kwargs):
         """
 
         The base class for all bayesian samplers. Provides a common interface
@@ -40,7 +43,9 @@ class SamplerBase(with_metaclass(abc.ABCMeta, object)):
 
 
         :param likelihood_model: the likelihood model
-        :param data_list: the data list 
+        :param data_list: the data list
+        :param share_spectrum: (optional) Should the spectrum be shared between detectors
+        with the same input energy bins?
         :returns: 
         :rtype: 
 
@@ -57,7 +62,62 @@ class SamplerBase(with_metaclass(abc.ABCMeta, object)):
         self._likelihood_model = likelihood_model
         self._data_list = data_list
         
+        # Share spectrum flag if the spectrum should only be calculated
+        # once when different data_list entries have the same input energy bins.
+        # Can speed up the fits a lot if many similar detectors are used.
+        if "share_spectrum" in kwargs:
+            self._share_spectrum = kwargs["share_spectrum"]
+            assert type(self._share_spectrum) == bool,\
+                "share_spectrum must be False or True."
+        else:
+            self._share_spectrum = False
 
+        if self._share_spectrum:
+            # Check which data_list entries have the same input energies in the response folding
+            found = False
+            num_found = 0
+            self._data_ein_edges = {}
+            for j, d in enumerate(list(self._data_list.values())):
+                if j == 0:
+                    if isinstance(d, DispersionSpectrumLike):
+                        self._data_ein_edges[num_found] = d.response.monte_carlo_energies
+                    elif isinstance(d, SpectrumLike):
+                        self._data_ein_edges[num_found] = d.observed_spectrum.edges
+                    else:
+                        raise AssertionError("Share spectrum only works for"\
+                                             " SpectrumLike instances.")
+                    # Build an array which saves which plugins have the same Ein_bins
+                    self._data_ebin_connect = np.array([0])
+                    num_found += 1
+
+                    # Get integral function. Should be the same for all plugins.
+                    _, self._integral = d._get_diff_flux_and_integral(
+                        likelihood_model,
+                        integrate_method=d._model_integrate_method
+                    )
+
+                else:
+                    if isinstance(d, DispersionSpectrumLike):
+                        e = d.response.monte_carlo_energies
+                    elif isinstance(d, SpectrumLike):
+                        e = d.observed_spectrum.edges
+                    else:
+                        raise AssertionError("At the moment share spectrum only works for"\
+                                             " SpectrumLike instances.")
+
+                    # Check if these Ein_bins are already used by an earlier plugin
+                    for i in range(len(self._data_ein_edges)):
+                        if len(e) == len(self._data_ein_edges[i]):
+                            if np.all(np.equal(e, self._data_ein_edges[i])):
+                                self._data_ebin_connect = np.append(self._data_ebin_connect, i)
+                                found = True
+
+                    # If not save these Ein_bins and add an entry to the connection array
+                    if not found:
+                        self._data_ein_edges[num_found] = e
+                        self._data_ebin_connect = np.append(self._data_ebin_connect, i+1)
+                        num_found += 1
+                    found = False
 
 
     @abc.abstractmethod
@@ -131,12 +191,12 @@ class SamplerBase(with_metaclass(abc.ABCMeta, object)):
         """
         Sets the model parameters to the mean of the marginal distributions
         """
-
+        idx = self._log_probability_values.argmax()
         for i, (parameter_name, parameter) in enumerate(self._free_parameters.items()):
-            # Add the samples for this parameter for this source
 
-            mean_par = np.median(self._samples[parameter_name])
-            parameter.value = mean_par
+            par = self._samples[parameter_name][idx]
+
+            parameter.value = par
 
     def _build_samples_dictionary(self):
         """
@@ -305,13 +365,32 @@ class SamplerBase(with_metaclass(abc.ABCMeta, object)):
         # Get the value of the log-likelihood for this parameters
 
         try:
-
             # Loop over each dataset and get the likelihood values for each set
+            if not self._share_spectrum:
+                # Old way; every dataset independendly - This is fine if the
+                # spectrum calc is fast.
+                log_like_values = [
+                    dataset.get_log_like() for dataset in list(self._data_list.values())
+                ]
+            else:
+                # If the calculation for the input spectrum of one of the sources is expensive
+                # we want to avoid calculating the same thing several times.
 
-            log_like_values = [
-                dataset.get_log_like() for dataset in list(self._data_list.values())
-            ]
+                # Precalc the spectrum for all different Ebin_in that are used in the plugins
+                log_like_values = np.zeros(len(self._data_ebin_connect))
+                precalc_fluxes = []
 
+                for i, e_edges in enumerate(list(self._data_ein_edges.values())):
+                    precalc_fluxes.append(self._integral(e_edges[:-1], e_edges[1:]))
+
+                # Use these precalculated spectra to get the log_like for all plugins
+                for i, dataset in enumerate(list(self._data_list.values())):
+                    # call get log_like with precalculated spectrum
+                    log_like_values[i] = \
+                        dataset.get_log_like(precalc_fluxes=
+                                             precalc_fluxes[self._data_ebin_connect[i]])
+
+        
         except ModelAssertionViolation:
 
             # Fit engine or sampler outside of allowed zone

--- a/threeML/plugins/DispersionSpectrumLike.py
+++ b/threeML/plugins/DispersionSpectrumLike.py
@@ -100,6 +100,21 @@ class DispersionSpectrumLike(SpectrumLike):
 
         return self._rsp.convolve(precalc_fluxes=precalc_fluxes)
 
+    def set_model_integrate_method(self,
+                                   method: str):
+        """
+        Change the integrate method for the model integration
+        :param method: (str) which method should be used (simpson or trapz)
+        """
+        assert method in ["simpson", "trapz"], "Only simpson and trapz are valid intergate methods."
+        self._model_integrate_method = method
+
+        # if like_model already set, upadte the integral function
+        if self._like_model is not None:
+            differential_flux, integral = self._get_diff_flux_and_integral(self._like_model,
+                                                                           integrate_method=method)
+            self._rsp._integral_function = integral
+
     def get_simulated_dataset(self, new_name=None, **kwargs):
         """
         Returns another DispersionSpectrumLike instance where data have been obtained by randomizing the current expectation from the

--- a/threeML/plugins/DispersionSpectrumLike.py
+++ b/threeML/plugins/DispersionSpectrumLike.py
@@ -1,4 +1,6 @@
 import copy
+from typing import Optional
+import numpy as np
 
 import pandas as pd
 
@@ -85,17 +87,18 @@ class DispersionSpectrumLike(SpectrumLike):
         # Get the differential flux function, and the integral function, with no dispersion,
         # we simply integrate the model over the bins
 
-        differential_flux, integral = self._get_diff_flux_and_integral(self._like_model)
+        differential_flux, integral = self._get_diff_flux_and_integral(self._like_model,
+                                                                       integrate_method=self._model_integrate_method)
 
         self._rsp.set_function(integral)
 
-    def _evaluate_model(self):
+    def _evaluate_model(self, precalc_fluxes: Optional[np.array]=None):
         """
         evaluates the full model over all channels
         :return:
         """
 
-        return self._rsp.convolve()
+        return self._rsp.convolve(precalc_fluxes=precalc_fluxes)
 
     def get_simulated_dataset(self, new_name=None, **kwargs):
         """

--- a/threeML/plugins/SpectrumLike.py
+++ b/threeML/plugins/SpectrumLike.py
@@ -7,7 +7,11 @@ from past.utils import old_div
 import collections
 import copy
 from contextlib import contextmanager
+from collections.abc import Iterable
+from typing import Optional, Union, Tuple
+import types
 
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -29,12 +33,10 @@ from threeML.utils.binner import Rebinner
 from threeML.utils.spectrum.binned_spectrum import BinnedSpectrum, ChannelSet
 
 from threeML.utils.string_utils import dash_separated_string_to_tuple
-from threeML.utils.spectrum.pha_spectrum import PHASpectrum
 
 from threeML.utils.statistics.stats_tools import Significance
 from threeML.utils.spectrum.spectrum_likelihood import statistic_lookup
 from threeML.io.plotting.data_residual_plot import ResidualPlot
-
 
 NO_REBIN = 1e-99
 
@@ -47,13 +49,13 @@ _known_noise_models = ["poisson", "gaussian", "ideal", "modeled"]
 class SpectrumLike(PluginPrototype):
     def __init__(
         self,
-        name,
-        observation,
+        name: str,
+        observation: BinnedSpectrum,
         background=None,
-        verbose=True,
+        verbose: bool=True,
         background_exposure=None,
-        tstart=None,
-        tstop=None,
+        tstart: Optional[Union[float,int]]=None,
+        tstop: Optional[Union[float,int]]=None,
     ):
         # type: (str, BinnedSpectrum, BinnedSpectrum, bool) -> None
         """
@@ -128,6 +130,10 @@ class SpectrumLike(PluginPrototype):
             self._back_count_errors,
         ) = self._count_errors_initialization()
 
+        # Init the integral methods for background and model integration to default
+        self._model_integrate_method = "simpson"
+        self._background_integrate_method = "simpson"
+
         # Initialize a mask that selects all the data.
         # We will initially use the quality mask for the PHA file
         # and set any quality greater than 0 to False. We want to save
@@ -174,7 +180,8 @@ class SpectrumLike(PluginPrototype):
                 # now get the background likelihood model
 
                 differential_flux, integral = self._get_diff_flux_and_integral(
-                    self._background_plugin.likelihood_model
+                    self._background_plugin.likelihood_model,
+                    integrate_method=self._background_integrate_method
                 )
 
                 self._background_integral_flux = integral
@@ -432,7 +439,9 @@ class SpectrumLike(PluginPrototype):
 
         return observation_noise_model, background_noise_model
 
-    def _background_setup(self, background, observation):
+    def _background_setup(self,
+                          background,
+                          observation: BinnedSpectrum):
         """
         
         :param background: background arguments (spectrum or plugin)
@@ -648,7 +657,10 @@ class SpectrumLike(PluginPrototype):
         return self._observed_spectrum
 
     @classmethod
-    def _get_synthetic_plugin(cls, observation, background, source_function):
+    def _get_synthetic_plugin(cls,
+                              observation: BinnedSpectrum,
+                              background,
+                              source_function):
 
         speclike_gen = cls("generator", observation, background, verbose=False)
 
@@ -694,7 +706,10 @@ class SpectrumLike(PluginPrototype):
         return observation
 
     @classmethod
-    def from_background(cls, name, spectrum_like, verbose=True):
+    def from_background(cls,
+                        name: str,
+                        spectrum_like,
+                        verbose: bool=True):
         """
         Extract a SpectrumLike plugin from the background of another SpectrumLike (or subclass) instance
 
@@ -716,7 +731,7 @@ class SpectrumLike(PluginPrototype):
     @classmethod
     def from_function(
         cls,
-        name,
+        name: str,
         source_function,
         energy_min,
         energy_max,
@@ -843,7 +858,8 @@ class SpectrumLike(PluginPrototype):
 
         return generator.get_simulated_dataset(name)
 
-    def assign_to_source(self, source_name):
+    def assign_to_source(self,
+                         source_name: str):
         """
         Assign these data to the given source (instead of to the sum of all sources, which is the default)
 
@@ -1552,7 +1568,7 @@ class SpectrumLike(PluginPrototype):
         doc="Sets/gets the noise model for the background spectrum",
     )
 
-    def get_log_like(self):
+    def get_log_like(self, precalc_fluxes: Optional[np.array]=None):
         """
         Calls the likelihood from the pre-setup likelihood evaluator that "knows" of the currently set
         noise models
@@ -1560,7 +1576,7 @@ class SpectrumLike(PluginPrototype):
         :return: 
         """
 
-        loglike, _ = self._likelihood_evaluator.get_current_value()
+        loglike, _ = self._likelihood_evaluator.get_current_value(precalc_fluxes=precalc_fluxes)
 
         return loglike
 
@@ -1594,11 +1610,12 @@ class SpectrumLike(PluginPrototype):
         # Get the differential flux function, and the integral function, with no dispersion,
         # we simply integrate the model over the bins
 
-        differential_flux, integral = self._get_diff_flux_and_integral(self._like_model)
+        differential_flux, integral = self._get_diff_flux_and_integral(self._like_model,
+                                                                       integrate_method=self._model_integrate_method)
 
         self._integral_flux = integral
 
-    def _evaluate_model(self):
+    def _evaluate_model(self, precalc_fluxes: Optional[np.array]=None):
         """
         Since there is no dispersion, we simply evaluate the model by integrating over the energy bins.
         This can be overloaded to convolve the model with a response, for example
@@ -1606,7 +1623,9 @@ class SpectrumLike(PluginPrototype):
 
         :return:
         """
-
+        if precalc_fluxes is not None:
+            return precalc_fluxes
+        
         return np.array(
             [
                 self._integral_flux(emin, emax)
@@ -1614,7 +1633,8 @@ class SpectrumLike(PluginPrototype):
             ]
         )
 
-    def get_model(self):
+    def get_model(self,
+                  precalc_fluxes: Optional[np.array]=None):
         """
         The model integrated over the energy bins. Note that it only returns the  model for the
         currently active channels/measurements
@@ -1625,13 +1645,13 @@ class SpectrumLike(PluginPrototype):
         if self._rebinner is not None:
 
             (model,) = self._rebinner.rebin(
-                self._evaluate_model() * self._observed_spectrum.exposure
+                self._evaluate_model(precalc_fluxes=precalc_fluxes) * self._observed_spectrum.exposure
             )
 
         else:
 
             model = (
-                self._evaluate_model()[self._mask] * self._observed_spectrum.exposure
+                self._evaluate_model(precalc_fluxes=precalc_fluxes)[self._mask] * self._observed_spectrum.exposure
             )
 
         return self._nuisance_parameter.value * model
@@ -1652,7 +1672,8 @@ class SpectrumLike(PluginPrototype):
             ]
         )
 
-    def get_background_model(self, without_mask=False):
+    def get_background_model(self,
+                             without_mask: bool=False):
         """
          The background model integrated over the energy bins. Note that it only returns the  model for the
          currently active channels/measurements
@@ -1687,7 +1708,12 @@ class SpectrumLike(PluginPrototype):
 
         return model
 
-    def _get_diff_flux_and_integral(self, likelihood_model):
+    def _get_diff_flux_and_integral(self,
+                                    likelihood_model: Model,
+                                    integrate_method: str="simpson") -> Tuple[types.FunctionType,
+                                                                              types.FunctionType]:
+
+        assert integrate_method in ["simpson", "trapz"], "Only simpson and trapz are valid integral_methods."
 
         if self._source_name is None:
 
@@ -1737,22 +1763,64 @@ class SpectrumLike(PluginPrototype):
         # decent models. It might fail for models with too sharp features, smaller
         # than the size of the monte carlo interval.
 
-        def integral(e1, e2):
-            # Simpson's rule
+        if integrate_method == "simpson":
 
-            return (
-                (e2 - e1)
-                / 6.0
-                * (
-                    differential_flux(e1)
-                    + 4 * differential_flux((e1 + e2) / 2.0)
-                    + differential_flux(e2)
-                )
-            )
+            # New way with simpson rule.
+            # Make sure to not calculate the model twice for the same energies
+            def integral(e1, e2):
+                # Simpson's rule
+                if isinstance(e1, Iterable):
+                    # Energy given as list or array
+
+                    # Make sure we do not calculate the flux two times at the same energy
+                    e_edges = np.append(e1, e2[-1])
+                    e_m = (e1+e2)/2.
+
+                    diff_fluxes_edges = differential_flux(e_edges)
+                    diff_fluxes_mid = differential_flux(e_m)
+
+                    return (
+                        (e2 - e1)
+                        / 6.0
+                        * (
+                            diff_fluxes_edges[:-1]
+                            + 4*diff_fluxes_mid
+                            + diff_fluxes_edges[1:]
+                        )
+                    )
+                else:
+                    #single energy values given
+                    return (
+                        (e2 - e1)
+                        / 6.0
+                        * (
+                            differential_flux(e1)
+                            + 4*differential_flux((e2 + e1) / 2.0)
+                            + differential_flux(e2)
+                        )
+                    )
+
+        elif integrate_method == "trapz":
+
+            def integral(e1, e2):
+                # Trapz rule
+                if isinstance(e1, Iterable):
+                    # Energy given as list or array
+
+                    # Make sure we do not calculate the flux two times at the same energy
+                    e_edges = np.append(e1, e2[-1])
+                    diff_fluxes_edges = differential_flux(e_edges)
+
+                    return np.trapz(np.array([diff_fluxes_edges[:-1], diff_fluxes_edges[1:]]).T,np.array([e1,e2]).T)
+                else:
+                    #single energy values given
+                    return np.trapz(np.array([differential_flux(e1), differential_flux(e2)]),np.array([e1,e2]))
 
         return differential_flux, integral
 
-    def use_effective_area_correction(self, min_value=0.8, max_value=1.2):
+    def use_effective_area_correction(self,
+                                      min_value: Union[int, float]=0.8,
+                                      max_value: Union[int, float]=1.2):
         """
         Activate the use of the effective area correction, which is a multiplicative factor in front of the model which
         might be used to mitigate the effect of intercalibration mismatch between different instruments.
@@ -1775,7 +1843,8 @@ class SpectrumLike(PluginPrototype):
 
         self._nuisance_parameter.set_uninformative_prior(Uniform_prior)
 
-    def fix_effective_area_correction(self, value=1):
+    def fix_effective_area_correction(self,
+                                      value: Union[int, float]=1):
         """
         Fix the multiplicative factor (see use_effective_area_correction) to the provided value (default: 1)
 
@@ -1785,6 +1854,36 @@ class SpectrumLike(PluginPrototype):
 
         self._nuisance_parameter.value = value
         self._nuisance_parameter.fix = True
+
+    def set_model_integrate_method(self,
+                                   method: str):
+        """
+        Change the integrate method for the model integration
+        :param method: (str) which method should be used (simpson or trapz)
+        """
+        assert method in ["simpson", "trapz"], "Only simpson and trapz are valid intergate methods."
+        self._model_integrate_method = method
+
+        # if like_model already set, upadte the integral function
+        if self._like_model is not None:
+            differential_flux, integral = self._get_diff_flux_and_integral(self._like_model,
+                                                                           integrate_method=method)
+            self._integral_flux = integral
+
+    def set_background_integrate_method(self,
+                                        method: str):
+        """
+        Change the integrate method for the background integration
+        :param method: (str) which method should be used (simpson or trapz)
+        """
+        assert method in ["simpson", "trapz"], "Only simpson and trapz are valid intergate methods."
+        self._background_integrate_method = method
+
+        # if background_plugin is set, update the integral function
+        if self._background_plugin is not None:
+            differential_flux, integral = self._get_diff_flux_and_integral(self._background_plugin.likelihood_model,
+                                                                           integrate_method=method)
+            self._background_integral_flux = integral
 
     @property
     def mask(self):
@@ -2136,12 +2235,12 @@ class SpectrumLike(PluginPrototype):
 
     def view_count_spectrum(
         self,
-        plot_errors=True,
-        show_bad_channels=True,
-        show_warn_channels=False,
-        significance_level=None,
-        scale_background=True,
-    ):
+        plot_errors: bool=True,
+        show_bad_channels: bool=True,
+        show_warn_channels: bool=False,
+        significance_level: bool=None,
+        scale_background: bool=True,
+    ) -> matplotlib.figure.Figure:
         """
         View the count and background spectrum. Useful to check energy selections.
         :param plot_errors: plot errors on the counts
@@ -2608,7 +2707,10 @@ class SpectrumLike(PluginPrototype):
 
         return self._output().to_string()
 
-    def _construct_counts_arrays(self, min_rate, ratio_residuals):
+    def _construct_counts_arrays(self,
+                                 min_rate: Union[int, float],
+                                 ratio_residuals: bool=False,
+                                 total_counts: bool=False) -> dict:
         """
 
         Build new arrays before or after a fit of rebinned data/model
@@ -2617,6 +2719,9 @@ class SpectrumLike(PluginPrototype):
 
         :param min_rate:
         :param ratio_residuals:
+        :param total_counts: Should this construct the total counts as "data". If not, the "data counts" are
+        observed-background and the model counts are only source counts. Otherwise "data counts" are observed
+        and model counts are source+background
         :return:
         """
 
@@ -2627,20 +2732,30 @@ class SpectrumLike(PluginPrototype):
 
         chan_width = energy_max - energy_min
 
+        # Source model
         expected_model_rate = self.expected_model_rate
 
-        # figure out the type of data
+        # Observed rate
+        observed_rate = old_div(self.observed_counts, self._observed_spectrum.exposure)
+        observed_rate_err = old_div(self.observed_count_errors, self._observed_spectrum.exposure)
 
-        src_rate = self.source_rate
-        src_rate_err = self.source_rate_error
-
-        # rebin on the source rate
+        # Background rate
+        if (self._background_noise_model is not None) or (self._background_plugin is not None):
+            background_rate = old_div(self.background_counts,
+                                      self._background_exposure) *\
+                                      self._area_ratio
+            background_rate_err = old_div(self.background_count_errors,
+                                          self._background_exposure) *\
+                                          self._area_ratio
+        else:
+            background_rate = np.zeros(len(observed_rate))
+            background_rate_err = np.zeros(len(observed_rate))
 
         # Create a rebinner if either a min_rate has been given, or if the current data set has no rebinned on its own
-
+        # rebin on expected model rate
         if (min_rate is not NO_REBIN) or (self._rebinner is None):
 
-            this_rebinner = Rebinner(src_rate, min_rate, self._mask)
+            this_rebinner = Rebinner(expected_model_rate, min_rate, self._mask)
 
         else:
 
@@ -2648,8 +2763,10 @@ class SpectrumLike(PluginPrototype):
             this_rebinner = self._rebinner
 
         # get the rebinned counts
-        new_rate, new_model_rate = this_rebinner.rebin(src_rate, expected_model_rate)
-        (new_err,) = this_rebinner.rebin_errors(src_rate_err)
+        new_observed_rate, new_model_rate, new_background_rate = \
+            this_rebinner.rebin(observed_rate, expected_model_rate, background_rate)
+        (new_observed_rate_err,) = this_rebinner.rebin_errors(observed_rate_err)
+        (new_background_rate_err,) = this_rebinner.rebin_errors(background_rate_err)
 
         # adjust channels
         new_energy_min, new_energy_max = this_rebinner.get_new_start_and_stop(
@@ -2670,7 +2787,7 @@ class SpectrumLike(PluginPrototype):
             idx = (mean_energy_unrebinned >= e_min) & (mean_energy_unrebinned <= e_max)
 
             # Find the rates for these channels
-            r = src_rate[idx]
+            r = observed_rate[idx]
 
             if r.max() == 0:
 
@@ -2750,6 +2867,9 @@ class SpectrumLike(PluginPrototype):
 
         # Divide the various cases
 
+
+        #TODO check this: shoudn't it be obseved-background/model (for the old way) and
+        # observed/(model+background) (for the new way). Errors also wrong observed+background error
         if ratio_residuals:
             residuals = old_div(
                 (rebinned_observed_counts - rebinned_model_counts),
@@ -2808,19 +2928,29 @@ class SpectrumLike(PluginPrototype):
         # so that we can extract them for plotting
 
         rebinned_quantities = dict(
-            new_rate=new_rate,
-            new_err=new_err,
+            # Rebined
+            #observed
+            new_observed_rate=new_observed_rate,
+            new_observed_rate_err=new_observed_rate_err,
+            #background
+            new_background_rate=new_background_rate,
+            new_background_rate_err=new_background_rate_err,
+            #model
+            new_model_rate=new_model_rate,
+            # New echans
             new_chan_width=new_chan_width,
             new_energy_min=new_energy_min,
             new_energy_max=new_energy_max,
             mean_energy=mean_energy,
+            #Residuals
             residuals=residuals,
             residual_errors=residual_errors,
             delta_energy=delta_energy,
+            #Unbinned model rate
             expected_model_rate=expected_model_rate,
+            #Unbinned echans
             energy_min=energy_min,
             energy_max=energy_max,
-            new_model_rate=new_model_rate,
             chan_width=chan_width,
         )
 
@@ -2828,19 +2958,24 @@ class SpectrumLike(PluginPrototype):
 
     def display_model(
         self,
-        data_color="k",
-        model_color="r",
-        step=True,
-        show_data=True,
-        show_residuals=True,
-        ratio_residuals=False,
-        show_legend=True,
-        min_rate=1e-99,
-        model_label=None,
-        model_kwargs=None,
-        data_kwargs=None,
+        data_color: str="k",
+        model_color: str="r",
+        background_color: str="b",
+        step: bool=True,
+        show_data: bool=True,
+        show_residuals: bool=True,
+        ratio_residuals: bool=False,
+        show_legend: bool=True,
+        min_rate: Union[int,float]=1e-99,
+        model_label: Optional[str]=None,
+        model_kwargs: Optional[dict]=None,
+        data_kwargs: Optional[dict]=None,
+        background_label: Optional[str]=None,
+        background_kwargs: Optional[dict]=None,
+        source_only: bool=True,
+        show_background: bool=False,
         **kwargs
-    ):
+    ) -> ResidualPlot:
 
         """
         Plot the current model with or without the data and the residuals. Multiple models can be plotted by supplying
@@ -2870,11 +3005,13 @@ class SpectrumLike(PluginPrototype):
 
         # set up the default plotting
 
-        _default_model_kwargs = dict(color=model_color, alpha=1.0)
+        _default_model_kwargs = dict(color=model_color, alpha=1)
+
+        _default_background_kwargs = dict(color=background_color, alpha=1, linestyle="--")
 
         _default_data_kwargs = dict(
             color=data_color,
-            alpha=1.0,
+            alpha=1,
             fmt=threeML_config["residual plot"]["error marker"],
             markersize=threeML_config["residual plot"]["error marker size"],
             linestyle="",
@@ -2910,6 +3047,20 @@ class SpectrumLike(PluginPrototype):
 
                     _default_data_kwargs[k] = v
 
+        if background_kwargs is not None:
+
+            assert type(background_kwargs) == dict, "background_kwargs must be a dict"
+
+            for k, v in list(background_kwargs.items()):
+
+                if k in _default_background_kwargs:
+
+                    _default_background_kwargs[k] = v
+
+                else:
+
+                    _default_background_kwargs[k] = v
+
         if model_label is None:
             model_label = "%s Model" % self._name
 
@@ -2919,12 +3070,30 @@ class SpectrumLike(PluginPrototype):
 
         rebinned_quantities = self._construct_counts_arrays(min_rate, ratio_residuals)
 
-        weighted_data = old_div(
-            rebinned_quantities["new_rate"], rebinned_quantities["new_chan_width"]
-        )
-        weighted_error = old_div(
-            rebinned_quantities["new_err"], rebinned_quantities["new_chan_width"]
-        )
+        if source_only:
+            y_label = "Net rate\n(counts s$^{-1}$ keV$^{-1}$)"
+            weighted_data = old_div(
+                rebinned_quantities["new_observed_rate"]-rebinned_quantities["new_background_rate"], rebinned_quantities["new_chan_width"]
+            )
+            weighted_error = old_div(
+                np.sqrt(rebinned_quantities["new_observed_rate_err"]**2+
+                        rebinned_quantities["new_background_rate_err"]**2),
+                rebinned_quantities["new_chan_width"]
+            )
+        else:
+            y_label = "Observed rate\n(counts s$^{-1}$ keV$^{-1}$)"
+            weighted_data = old_div(
+                rebinned_quantities["new_observed_rate"], rebinned_quantities["new_chan_width"]
+            )
+            weighted_error = old_div(
+                rebinned_quantities["new_observed_rate_err"], rebinned_quantities["new_chan_width"]
+            )
+        #weighted_data = old_div(
+        #    rebinned_quantities["new_rate"], rebinned_quantities["new_chan_width"]
+        #)
+        #weighted_error = old_div(
+        #    rebinned_quantities["new_err"], rebinned_quantities["new_chan_width"]
+        #)
 
         residual_plot.add_data(
             rebinned_quantities["mean_energy"],
@@ -2938,17 +3107,40 @@ class SpectrumLike(PluginPrototype):
             **_default_data_kwargs
         )
 
-        # a step historgram
-        if step:
-
+        if show_background:
             residual_plot.add_model_step(
                 rebinned_quantities["new_energy_min"],
                 rebinned_quantities["new_energy_max"],
                 rebinned_quantities["new_chan_width"],
-                rebinned_quantities["new_model_rate"],
+                rebinned_quantities["new_background_rate"],
+                label=background_label,
+                **_default_background_kwargs
+                )
+
+        # a step historgram
+        if step:
+            if source_only:
+                # only source
+                eff_model = rebinned_quantities["new_model_rate"]
+            else:
+                eff_model = rebinned_quantities["new_model_rate"] + rebinned_quantities["new_background_rate"]
+            residual_plot.add_model_step(
+                rebinned_quantities["new_energy_min"],
+                rebinned_quantities["new_energy_max"],
+                rebinned_quantities["new_chan_width"],
+                eff_model,
                 label=model_label,
                 **_default_model_kwargs
             )
+
+            #residual_plot.add_model_step(
+            #    rebinned_quantities["new_energy_min"],
+            #    rebinned_quantities["new_energy_max"],
+            #    rebinned_quantities["new_chan_width"],
+            #    rebinned_quantities["new_model_rate"],
+            #    label=model_label,
+            #    **_default_model_kwargs
+            #)
 
         else:
 
@@ -2973,7 +3165,7 @@ class SpectrumLike(PluginPrototype):
 
         return residual_plot.finalize(
             xlabel="Energy\n(keV)",
-            ylabel="Net rate\n(counts s$^{-1}$ keV$^{-1}$)",
+            ylabel=y_label,
             xscale="log",
             yscale="log",
             show_legend=show_legend,

--- a/threeML/test/conftest.py
+++ b/threeML/test/conftest.py
@@ -60,29 +60,31 @@ def get_grb_model(spectrum):
 
 def get_test_datasets_directory():
 
-    return os.path.abspath(os.path.join(get_path_of_data_dir(), "datasets"))
+    return Path(get_path_of_data_dir(), "datasets").absolute()
 
 
 def get_dataset():
 
-    datadir = os.path.join(get_test_datasets_directory(), "bn090217206")
+    data_dir = Path(get_test_datasets_directory(), "bn090217206")
 
-    obsSpectrum = os.path.join(datadir, "bn090217206_n6_srcspectra.pha{1}")
-    bakSpectrum = os.path.join(datadir, "bn090217206_n6_bkgspectra.bak{1}")
-    rspFile = os.path.join(datadir, "bn090217206_n6_weightedrsp.rsp{1}")
-    NaI6 = OGIPLike("NaI6", obsSpectrum, bakSpectrum, rspFile)
+    obs_spectrum = Path(data_dir, "bn090217206_n6_srcspectra.pha{1}")
+    bak_spectrum = Path(data_dir, "bn090217206_n6_bkgspectra.bak{1}")
+    rsp_file = Path(data_dir, "bn090217206_n6_weightedrsp.rsp{1}")
+    NaI6 = OGIPLike("NaI6", str(obs_spectrum),
+                    str(bak_spectrum), str(rsp_file))
     NaI6.set_active_measurements("10.0-30.0", "40.0-950.0")
 
     return NaI6
 
 def get_dataset_det(det):
 
-    datadir = os.path.join(get_test_datasets_directory(), "bn090217206")
+    data_dir = Path(get_test_datasets_directory(), "bn090217206")
 
-    obsSpectrum = os.path.join(datadir, f"bn090217206_{det}_srcspectra.pha{{1}}")
-    bakSpectrum = os.path.join(datadir, f"bn090217206_{det}_bkgspectra.bak{{1}}")
-    rspFile = os.path.join(datadir, f"bn090217206_{det}_weightedrsp.rsp{{1}}")
-    p = OGIPLike(det, obsSpectrum, bakSpectrum, rspFile)
+    obs_spectrum = Path(data_dir, f"bn090217206_{det}_srcspectra.pha{{1}}")
+    bak_spectrum = Path(data_dir, f"bn090217206_{det}_bkgspectra.bak{{1}}")
+    rsp_file = Path(data_dir, f"bn090217206_{det}_weightedrsp.rsp{{1}}")
+    p = OGIPLike(det, str(obs_spectrum),
+                 str(bak_spectrum), str(rsp_file))
     if det[0] == "b":
         p.set_active_measurements("250-25000")
     else:

--- a/threeML/test/conftest.py
+++ b/threeML/test/conftest.py
@@ -75,6 +75,21 @@ def get_dataset():
 
     return NaI6
 
+def get_dataset_det(det):
+
+    datadir = os.path.join(get_test_datasets_directory(), "bn090217206")
+
+    obsSpectrum = os.path.join(datadir, f"bn090217206_{det}_srcspectra.pha{{1}}")
+    bakSpectrum = os.path.join(datadir, f"bn090217206_{det}_bkgspectra.bak{{1}}")
+    rspFile = os.path.join(datadir, f"bn090217206_{det}_weightedrsp.rsp{{1}}")
+    p = OGIPLike(det, obsSpectrum, bakSpectrum, rspFile)
+    if det[0] == "b":
+        p.set_active_measurements("250-25000")
+    else:
+        p.set_active_measurements("10.0-30.0", "40.0-950.0")
+
+    return p
+
 
 @pytest.fixture(scope="session")
 def data_list_bn090217206_nai6():
@@ -85,6 +100,17 @@ def data_list_bn090217206_nai6():
 
     return data_list
 
+@pytest.fixture(scope="session")
+def data_list_bn090217206_nai6_nai9_bgo1():
+
+    p_list = []
+    p_list.append(get_dataset_det("n6"))
+    p_list.append(get_dataset_det("n9"))
+    p_list.append(get_dataset_det("b1"))
+
+    data_list = DataList(*p_list)
+
+    return data_list
 
 # This is going to be run every time a test need it, so the jl object
 # is always "fresh"
@@ -99,6 +125,19 @@ def joint_likelihood_bn090217206_nai(data_list_bn090217206_nai6):
 
     return jl
 
+# This is going to be run every time a test need it, so the jl object
+# is always "fresh"
+@pytest.fixture(scope="function")
+def joint_likelihood_bn090217206_nai6_nai9_bgo1(data_list_bn090217206_nai6_nai9_bgo1):
+
+    powerlaw = Powerlaw()
+
+    model = get_grb_model(powerlaw)
+
+    jl = JointLikelihood(model, data_list_bn090217206_nai6_nai9_bgo1, verbose=False)
+
+    return jl
+
 
 # No need to keep refitting, so we fit once (scope=session)
 @pytest.fixture(scope="function")
@@ -110,6 +149,15 @@ def fitted_joint_likelihood_bn090217206_nai(joint_likelihood_bn090217206_nai):
 
     return jl, fit_results, like_frame
 
+# No need to keep refitting, so we fit once (scope=session)
+@pytest.fixture(scope="function")
+def fitted_joint_likelihood_bn090217206_nai6_nai9_bgo1(joint_likelihood_bn090217206_nai6_nai9_bgo1):
+
+    jl = joint_likelihood_bn090217206_nai6_nai9_bgo1
+
+    fit_results, like_frame = jl.fit()
+
+    return jl, fit_results, like_frame
 
 def set_priors(model):
 

--- a/threeML/test/test_plotting.py
+++ b/threeML/test/test_plotting.py
@@ -3,7 +3,8 @@ from threeML import *
 from threeML.utils.binner import NotEnoughData
 
 
-def test_OGIP_plotting(fitted_joint_likelihood_bn090217206_nai):
+def test_OGIP_plotting(fitted_joint_likelihood_bn090217206_nai,
+                       fitted_joint_likelihood_bn090217206_nai6_nai9_bgo1):
 
     jl, _, _ = fitted_joint_likelihood_bn090217206_nai
 
@@ -21,7 +22,11 @@ def test_OGIP_plotting(fitted_joint_likelihood_bn090217206_nai):
 
     _ = display_spectrum_model_counts(jl)
 
-    _ = display_spectrum_model_counts(jl, data=("NaI6"))
+    _ = display_spectrum_model_counts(jl,
+                                      data=("NaI6"),
+                                      model_color=["red", "blue"],
+                                      data_color=["red", "blue"],
+                                      show_legend=False)
 
     _ = display_spectrum_model_counts(jl, data=("wrong"))
 
@@ -30,3 +35,20 @@ def test_OGIP_plotting(fitted_joint_likelihood_bn090217206_nai):
     with pytest.raises(NotEnoughData):
 
         _ = display_spectrum_model_counts(jl, min_rate=1e8)
+
+    # Load jl object with len(data_list)=3
+    jl, _, _ = fitted_joint_likelihood_bn090217206_nai6_nai9_bgo1
+
+    _ = display_spectrum_model_counts(jl,
+                                      data_per_plot=2,
+                                      data_cmap="viridis",
+                                      model_cmap="viridis",
+                                      show_legend=False)
+
+    _ = display_spectrum_model_counts(jl,
+                                      data_per_plot=2,
+                                      data_cmap="viridis",
+                                      model_cmap="viridis",
+                                      background_cmap="cool",
+                                      show_background=True,
+                                      source_only=True)

--- a/threeML/utils/OGIP/response.py
+++ b/threeML/utils/OGIP/response.py
@@ -9,9 +9,11 @@ import astropy.io.fits as pyfits
 import astropy.units as u
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
+from typing import Optional
 import numpy as np
 from matplotlib.colors import SymLogNorm
 from past.utils import old_div
+
 
 from threeML.exceptions.custom_exceptions import custom_warnings
 from threeML.io.file_utils import (file_existing_and_readable,
@@ -205,11 +207,19 @@ class InstrumentResponse(object):
 
         self._integral_function = integral_function
 
-    def convolve(self):
 
-        true_fluxes = self._integral_function(
-            self._mc_energies[:-1], self._mc_energies[1:]
-        )
+    def convolve(self, precalc_fluxes: Optional[np.array]=None):
+        """
+        Convolve the source flux with the response
+        :param precalc_fluxes: The precalulated flux. If this is None, the
+        flux gets calculated here.
+        """
+        if precalc_fluxes is None:
+            fluxes = self._integral_function(
+                self._mc_energies[:-1], self._mc_energies[1:]
+            )
+        else:
+            fluxes = precalc_fluxes
 
         # Sometimes some channels have 0 lenths, or maybe they start at 0, where
         # many functions (like a power law) are not defined. In the response these
@@ -217,10 +227,10 @@ class InstrumentResponse(object):
         # inf * zero != zero. Thus, let's force this. We avoid checking this situation
         # in details because this would have a HUGE hit on performances
 
-        idx = np.isfinite(true_fluxes)
-        true_fluxes[~idx] = 0
+        idx = np.isfinite(fluxes)
+        fluxes[~idx] = 0
 
-        folded_counts = np.dot(true_fluxes, self._matrix.T)
+        folded_counts = np.dot(fluxes, self._matrix.T)
 
         return folded_counts
 

--- a/threeML/utils/spectrum/binned_spectrum.py
+++ b/threeML/utils/spectrum/binned_spectrum.py
@@ -565,7 +565,6 @@ class BinnedSpectrum(Histogram):
         :param use_poly:
         :return:
         """
-        raise NotImplementedError("This is still under construction")
 
         pha_information = time_series.get_information_dict(use_poly)
 
@@ -578,15 +577,17 @@ class BinnedSpectrum(Histogram):
             instrument=pha_information["instrument"],
             mission=pha_information["telescope"],
             tstart=pha_information["tstart"],
-            telapse=pha_information["telapse"],
+            tstop=pha_information["tstart"]+pha_information["telapse"],
+            #telapse=pha_information["telapse"],
             # channel=pha_information['channel'],
             counts=pha_information["counts"],
             count_errors=pha_information["counts error"],
             quality=pha_information["quality"],
-            grouping=pha_information["grouping"],
+            #grouping=pha_information["grouping"],
             exposure=pha_information["exposure"],
-            backscale=1.0,
+            #backscale=1.0,
             is_poisson=is_poisson,
+            ebounds=pha_information["edges"]
         )
 
     def __add__(self, other):

--- a/threeML/utils/spectrum/spectrum_likelihood.py
+++ b/threeML/utils/spectrum/spectrum_likelihood.py
@@ -1,5 +1,6 @@
 from builtins import object
 import copy
+from typing import Optional
 
 import numpy as np
 
@@ -50,11 +51,14 @@ class BinnedStatistic(object):
 
 
 class GaussianObservedStatistic(BinnedStatistic):
-    def get_current_value(self):
+    def get_current_value(self, precalc_fluxes: Optional[np.array]=None):
+        
+        model_counts = self._spectrum_plugin.get_model(precalc_fluxes=precalc_fluxes)
+
         chi2_ = half_chi2(
             self._spectrum_plugin.current_observed_counts,
             self._spectrum_plugin.current_observed_count_errors,
-            self._spectrum_plugin.get_model(),
+            model_counts,
         )
 
         assert np.all(np.isfinite(chi2_))
@@ -92,11 +96,11 @@ class GaussianObservedStatistic(BinnedStatistic):
 
 
 class PoissonObservedIdealBackgroundStatistic(BinnedStatistic):
-    def get_current_value(self):
+    def get_current_value(self, precalc_fluxes: Optional[np.array]=None):
         # In this likelihood the background becomes part of the model, which means that
         # the uncertainty in the background is completely neglected
 
-        model_counts = self._spectrum_plugin.get_model()
+        model_counts = self._spectrum_plugin.get_model(precalc_fluxes=precalc_fluxes)
 
         loglike, _ = poisson_log_likelihood_ideal_bkg(
             self._spectrum_plugin.current_observed_counts,
@@ -127,11 +131,11 @@ class PoissonObservedIdealBackgroundStatistic(BinnedStatistic):
 
 
 class PoissonObservedModeledBackgroundStatistic(BinnedStatistic):
-    def get_current_value(self):
+    def get_current_value(self, precalc_fluxes: Optional[np.array]=None):
         # In this likelihood the background becomes part of the model, which means that
         # the uncertainty in the background is completely neglected
 
-        model_counts = self._spectrum_plugin.get_model()
+        model_counts = self._spectrum_plugin.get_model(precalc_fluxes=precalc_fluxes)
 
         # we scale the background model to the observation
 
@@ -181,11 +185,11 @@ class PoissonObservedModeledBackgroundStatistic(BinnedStatistic):
 
 
 class PoissonObservedNoBackgroundStatistic(BinnedStatistic):
-    def get_current_value(self):
+    def get_current_value(self, precalc_fluxes: Optional[np.array]=None):
         # In this likelihood the background becomes part of the model, which means that
         # the uncertainty in the background is completely neglected
 
-        model_counts = self._spectrum_plugin.get_model()
+        model_counts = self._spectrum_plugin.get_model(precalc_fluxes=precalc_fluxes)
 
         background_model_counts = np.zeros_like(model_counts)
 
@@ -207,10 +211,9 @@ class PoissonObservedNoBackgroundStatistic(BinnedStatistic):
 
 
 class PoissonObservedPoissonBackgroundStatistic(BinnedStatistic):
-    def get_current_value(self):
+    def get_current_value(self, precalc_fluxes: Optional[np.array]=None):
         # Scale factor between source and background spectrum
-
-        model_counts = self._spectrum_plugin.get_model()
+        model_counts = self._spectrum_plugin.get_model(precalc_fluxes=precalc_fluxes)
 
         loglike, bkg_model = poisson_observed_poisson_background(
             self._spectrum_plugin.current_observed_counts,
@@ -248,8 +251,8 @@ class PoissonObservedPoissonBackgroundStatistic(BinnedStatistic):
 
 
 class PoissonObservedGaussianBackgroundStatistic(BinnedStatistic):
-    def get_current_value(self):
-        expected_model_counts = self._spectrum_plugin.get_model()
+    def get_current_value(self, precalc_fluxes: Optional[np.array]=None):
+        expected_model_counts = self._spectrum_plugin.get_model(precalc_fluxes=precalc_fluxes)
 
         loglike, bkg_model = poisson_observed_gaussian_background(
             self._spectrum_plugin.current_observed_counts,

--- a/threeML/utils/time_series/binned_spectrum_series.py
+++ b/threeML/utils/time_series/binned_spectrum_series.py
@@ -51,6 +51,7 @@ class BinnedSpectrumSeries(TimeSeries):
             mission,
             instrument,
             verbose,
+            binned_spectrum_set._binned_spectrum_list[0].edges
         )
 
         self._binned_spectrum_set = binned_spectrum_set


### PR DESCRIPTION
Add/Improve a few features:

Major:

1. Add an option "share_spectrum" to the bayesian base_sampler. If this is set to True, it is checked in the beginning, if several detectors in the data_list have the same input Energy-bins. If yes, we can use this information to only calculate the spectrum once and distribute to the different detectors that use the same input Energy-bins. Can give a huge speed improvement if the spectrum calculation is slow and many similar detectors are used (like for GBM or SPI). Only works for SpectrumLike and DispersionSpectrumLike.
Can be used like this: 
ba = BayesianAnalysis(model, datalist)
ba.set_sampler("multinest", share_spectrum=True)

2. The integral function in SpectrumLike calculates the spectrum for every e1, e2 and (e1+e2)/2 (e1 lower ends and e2 upper ends of all input Energy-Bins) for the simpson integration. But, as this is the integration on the input side, there will be no gaps in the energy bins, therefore e2[i-1]=e1[i] => The spectrum is calculated two times for the same energy value. This was changed to just calcualte the spectrum at every Ebin-Edge (and also still the middle Energy-Bin values) and therefore gives a speedup of ~ 1/3 for the integration of the incoming flux.

3. Give the posibility to also use a trapz integration instead of the simpson integration. Less accurate, but needs only have the number of spectrum evaluations. -> speed up of ~ 1/2 for the integration of the incoming flux. 
Can be changed with SpectrumLike.set_model_integrate_method("trapz") for the source model integration or SpectrumLike.set_background_integrate_method("trapz") for the background spectrum integration. Simpson integration is still the 
default.

Plotting:
1. Fix cmap input for the display_spectrum_model_counts function.
2. Add an option "data_per_plot" to display_spectrum_model_counts, with which one can specify how many detetors should be plotted in one plot. If num_detectors>data_per_plot, the plotting is splitted into several plots.
3. Add an option "show_background" to display_spectrum_model_counts/display_model that will additionally plot the background rate.
4. Add an option "source_only" to display_spectrum_model_counts/display_model. If this is set to True, the "data" that is plotted, is observed_data-background_model and the model is only the source model (This is how it is done up to now). If this is set to False, the data is the observed_data and the model is the source_model+background_model.

Minor:
1. Added a few typings for the things I changed.
2. Changed the construct_counts_array method in SpectrumLike to store a few more information, like for example the background rate (needed for the new plotting)
3. Change the restore_median_fit function for bayesian sampler. Do not set every parameter to the median of the individual posterior distributions, but rather set the parameters to the sample with max loglike.
5. Add test for the share_spectrum, improve tests for display_spectrum_model_counts, to cover more of the optional input.
4. Small change in BinnedSpectrumSeries to make it possible to construct it from BinnedSpectra with no dispersion. 