### PR TITLE
Small bug fix/enhancement in fermi catalog

### DIFF
--- a/threeML/catalogs/Fermi.py
+++ b/threeML/catalogs/Fermi.py
@@ -730,22 +730,26 @@ class FermiLATSourceCatalog(VirtualObservatoryCatalog):
 
     def apply_format(self, table):
         def translate(key):
+            if isinstance(key, bytes):
+                key = key.decode("ascii")
             if key.lower() == "psr":
                 return threefgl_types[key]
             if key.lower() in list(threefgl_types.keys()):
                 return threefgl_types[key.lower()]
-            return "unknown"
+            return key
 
         # Translate the 3 letter code to a more informative category, according
         # to the dictionary above
 
-        table["source_type"] = numpy.array(list(map(translate, table["source_type"])))
+        table["short_source_type"] = table["source_type"]
+        table["source_type"] = numpy.array(list(map(translate, table["short_source_type"])))
 
-        try:
+        if "Search_Offset" in table.columns:
 
             new_table = table[
                 "name",
                 "source_type",
+                "short_source_type",
                 "ra",
                 "dec",
                 "assoc_name",
@@ -756,10 +760,10 @@ class FermiLATSourceCatalog(VirtualObservatoryCatalog):
             return new_table.group_by("Search_Offset")
 
         # we may have not done a cone search!
-        except (ValueError):
+        else:
 
             new_table = table[
-                "name", "source_type", "ra", "dec", "assoc_name", "tevcat_assoc"
+                "name", "source_type", "short_source_type" "ra", "dec", "assoc_name", "tevcat_assoc"
             ]
 
             return new_table.group_by("name")


### PR DESCRIPTION
Fix issue with string encoding when converting short source type to long source type.

Retain original source type as well in case the user wants to perform filtering later on.