### PR TITLE
Allow fitting the source position with the fermipy plugin

### DIFF
--- a/threeML/plugins/FermipyLike.py
+++ b/threeML/plugins/FermipyLike.py
@@ -532,14 +532,14 @@ class FermipyLike(PluginPrototype):
         :return: number of bins
         """
         
-        num = len(self._gta.components) * self._gta._enumbins
+        num = len(self._gta.components)
         
         if self._gta.projtype == "WCS":
 
-            num = num * self._gta.npix[0] * self._gta.npix[1]
+            num = num * self._gta._enumbins * int(self._gta.npix[0]) * int(self._gta.npix[1])
 
         if self._gta.projtype == "HPX":
         
-            num = num * np.max(self.geom.npix) ##Need to test this!
+            num = num * np.sum(self.geom.npix)
             
         return num

--- a/threeML/plugins/FermipyLike.py
+++ b/threeML/plugins/FermipyLike.py
@@ -525,3 +525,21 @@ class FermipyLike(PluginPrototype):
         """
         return self.get_log_like()
 
+    def get_number_of_data_points(self):
+        """
+        Return the number of spatial/energy bins
+
+        :return: number of bins
+        """
+        
+        num = len(self._gta.components) * self._gta._enumbins
+        
+        if self._gta.projtype == "WCS":
+
+            num = num * self._gta.npix[0] * self._gta.npix[1]
+
+        if self._gta.projtype == "HPX":
+        
+            num = num * np.max(self.geom.npix) ##Need to test this!
+            
+        return num


### PR DESCRIPTION
Implements #427 

I was able to fit the position of Mrk 421 with these changes (using a month of LAT data above 100 MeV) and get something comparable to fermipy (sorry about the swapped axes):

![Mrk_pos](https://user-images.githubusercontent.com/7796998/108930427-e72eeb00-7613-11eb-8aa9-4040d03d387d.png)

![4fgl_j1104 4+3812_localize_peak](https://user-images.githubusercontent.com/7796998/108930707-691f1400-7614-11eb-8469-f6b679fadbc9.png)


The fit is very slow and a bit finicky (can't start at the "right" values). I ended up fixing the spectral shape because it seemed to take forever otherwise. Might be easier with more data.

I also added a `get_number_of_data_points` function which the fermipy plugin was missing, would like to hear thoughts on that. 

