### PR TITLE
Restore model parameters after likelihood contour calculation

### DIFF
--- a/threeML/classicMLE/joint_likelihood.py
+++ b/threeML/classicMLE/joint_likelihood.py
@@ -495,6 +495,9 @@ class JointLikelihood(object):
                  size param_1_steps.
         """
 
+        # Clone model to restore later
+        model_clone = clone_model(self._likelihood_model)
+
         if hasattr(param_1, "value"):
 
             # Substitute with the name
@@ -781,7 +784,7 @@ class JointLikelihood(object):
 
                 aidx, bidx = np.unravel_index(idx, cc.shape)
 
-                print(
+                log.warning(
                     "\nFound a better minimum: %s with %s = %s and %s = %s. Run again your fit starting from here."
                     % (cc.min(), param_1, a[aidx], param_2, b[bidx])
                 )
@@ -790,11 +793,16 @@ class JointLikelihood(object):
 
                 idx = cc.argmin()
 
-                print(
+                log.warning(
                     "Found a better minimum: %s with %s = %s. Run again your fit starting from here."
                     % (cc.min(), param_1, a[idx])
                 )
-
+        
+        else:
+            #restore model
+            for param in self._likelihood_model.parameters:
+                self._likelihood_model.parameters[param].value = model_clone[param].value
+        
         return a, b, cc, fig
 
     def plot_all_contours(self, nsteps_1d, nsteps_2d=0, n_sigma=5, log_norm=True):

--- a/threeML/classicMLE/joint_likelihood.py
+++ b/threeML/classicMLE/joint_likelihood.py
@@ -495,9 +495,6 @@ class JointLikelihood(object):
                  size param_1_steps.
         """
 
-        # Clone model to restore later
-        model_clone = clone_model(self._likelihood_model)
-
         if hasattr(param_1, "value"):
 
             # Substitute with the name
@@ -800,8 +797,7 @@ class JointLikelihood(object):
         
         else:
             #restore model
-            for param in self._likelihood_model.parameters:
-                self._likelihood_model.parameters[param].value = model_clone[param].value
+            self.restore_best_fit()
         
         return a, b, cc, fig
 

--- a/threeML/test/test_minimizers.py
+++ b/threeML/test/test_minimizers.py
@@ -4,6 +4,7 @@ import numpy as np
 from threeML import LocalMinimization, GlobalMinimization
 from threeML import parallel_computation
 
+from astromodels import clone_model
 
 try:
 
@@ -61,6 +62,21 @@ def do_analysis(jl, minimizer):
 
     check_results(fit_results)
     
+def do_contours_check(jl, minimizer):
+
+    #make sure that model is restored after contour calculation
+
+    jl.set_minimizer(minimizer)
+    
+    _ = jl.fit()
+    
+    model_clone = clone_model(jl._likelihood_model)
+
+    _ = jl.get_contours( jl._likelihood_model.bn090217206.spectrum.main.Powerlaw.index, -3.5, -0.5, 30 )
+
+    for param in jl._likelihood_model.parameters:
+        assert jl._likelihood_model.parameters[param].value == model_clone[param].value
+    
 
 def test_minuit_simple(joint_likelihood_bn090217206_nai):
 
@@ -74,11 +90,14 @@ def test_minuit_complete(joint_likelihood_bn090217206_nai):
 
     do_analysis(joint_likelihood_bn090217206_nai, minuit)
 
+    do_contours_check( joint_likelihood_bn090217206_nai, "minuit" )
+
 
 @skip_if_ROOT_is_not_available
 def test_ROOT_simple(joint_likelihood_bn090217206_nai):
 
     do_analysis(joint_likelihood_bn090217206_nai, "ROOT")
+
 
 
 @skip_if_ROOT_is_not_available
@@ -88,6 +107,8 @@ def test_ROOT_complete(joint_likelihood_bn090217206_nai):
     root.setup(ftol=1e-3, max_function_calls=10000, strategy=2)
 
     do_analysis(joint_likelihood_bn090217206_nai, root)
+
+    do_contours_check( joint_likelihood_bn090217206_nai, "minuit" )
 
 
 def test_grid(joint_likelihood_bn090217206_nai):


### PR DESCRIPTION
Before, the model parameters were left at the values corresponding to the last step of the contour calculation, which is annoying if you want to keep going afterwards. This makes it so the model parameters are restored to the values before `get_contours` was called.