### PR TITLE
Configure fermipy logging to be less verbose

### DIFF
--- a/docs/md_docs/Fermipy_LAT.md
+++ b/docs/md_docs/Fermipy_LAT.md
@@ -119,14 +119,13 @@ evfile, scfile = download_LAT_data(
 3ML provides and intreface into [Fermipy](https://fermipy.readthedocs.io/en/latest/) via the **FermipyLike** plugin. We can use it to generate basic configuration files.
 
 
-<!-- #raw -->
+
 .. note::
     Currently, the FermipyLike plugin does not provide an interface to handle extended sources. This will change
 
-<!-- #endraw -->
 
 ```python
-config = FermipyLike.get_basic_config(evfile=evfile, scfile=scfile, ra=ra, dec=dec)
+config = FermipyLike.get_basic_config(evfile=evfile, scfile=scfile, ra=ra, dec=dec, fermipy_verbosity = 1, fermitools_chatter = 0)
 
 # See what we just got
 
@@ -143,11 +142,6 @@ and even add sections
 
 ```python
 config["gtlike"] = {"edisp": False}
-
-config["logging"] = {}
-config["logging"]["verbosity"] = 1 #print only error and critical messages. 
-#In fermipy convention, 0 would mean critical only, 2 would include warnings, 3 also info, 4 also debug) 
-config["logging"]["chatter"] = 0 #no screen output. 2 means some output, 4 means a lot of output.
 
 config.display()
 ```

--- a/docs/md_docs/Fermipy_LAT.md
+++ b/docs/md_docs/Fermipy_LAT.md
@@ -5,8 +5,8 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.2'
-      jupytext_version: 1.7.1
+      format_version: '1.3'
+      jupytext_version: 1.10.2
   kernelspec:
     display_name: Python 3
     language: python
@@ -41,6 +41,7 @@ import scipy as sp
 from threeML import *
 
 ```
+
 
 ```python nbsphinx="hidden"
 from jupyterthemes import jtplot
@@ -142,6 +143,11 @@ and even add sections
 
 ```python
 config["gtlike"] = {"edisp": False}
+
+config["logging"] = {}
+config["logging"]["verbosity"] = 1 #print only error and critical messages. 
+#In fermipy convention, 0 would mean critical only, 2 would include warnings, 3 also info, 4 also debug) 
+config["logging"]["chatter"] = 0 #no screen output. 2 means some output, 4 means a lot of output.
 
 config.display()
 ```
@@ -305,6 +311,7 @@ res = bayes.sample()
 
 ```
 
+
 You can access to the parameter range like this (HPD):
 
 ```python
@@ -324,4 +331,9 @@ print('Index (95%%): %10.2e,%10.2e' % this_idx.highest_posterior_density_interva
 
 ```python
 corner_figure = bayes.results.corner_plot()
+corner_figure
+```
+
+```python
+
 ```

--- a/threeML/data/fermipy_basic_config.yml
+++ b/threeML/data/fermipy_basic_config.yml
@@ -18,3 +18,7 @@ selection :
   filter  : 'DATA_QUAL>0 && LAT_CONFIG==1'
   ra :
   dec :
+
+logging:
+  verbosity : 2
+  chatter   : 2

--- a/threeML/plugins/FermipyLike.py
+++ b/threeML/plugins/FermipyLike.py
@@ -346,6 +346,8 @@ class FermipyLike(PluginPrototype):
         evclass=128,
         evtype=3,
         filter="DATA_QUAL>0 && LAT_CONFIG==1",
+        fermipy_verbosity = 2,
+        fermitools_chatter = 2,
     ):
 
         from fermipy.config import ConfigManager
@@ -408,6 +410,11 @@ class FermipyLike(PluginPrototype):
         basic_config["selection"]["evtype"] = evtype
 
         basic_config["selection"]["filter"] = filter
+
+        basic_config["logging"]["verbosity"] = fermipy_verbosity
+        #(In fermipy convention, 0 = critical only, 1 also errors, 2 also warnings, 3 also info, 4 also debug)
+        basic_config["logging"]["chatter"] = fermitools_chatter #0 = no screen output. 2 = some output, 4 = lot of output.
+
 
         return DictWithPrettyPrint(basic_config)
 


### PR DESCRIPTION
Ok, I've found out how to configure logging in fermipy. This gets rid of most of the output. I'm still seeing some output when the JointLikelihood / BayesianAnalysis objects are instantiated (which is when the GTAnalysis is first set up:

```
Found Galactic template for IRF. P8R2_SOURCE_V6: /Users/ich/hawc_software/miniconda3/envs/fermipy3ML/share/fermitools/refdata/fermi/galdiffuse/gll_iem_v07.fits

Cutting the template around the ROI: 

Found Isotropic template for irf P8R2_SOURCE_V6: /Users/ich/hawc_software/miniconda3/envs/fermipy3ML/share/fermitools/refdata/fermi/galdiffuse/iso_P8R2_SOURCE_V6_v06.txt
```

The above is as far as I can tell hardcoded to `print()` in the fermi tools, so won't be configurable with the logger.

I'm also seeing a bunch of

```
WARNING: Point source PKS_0459p060 lies 17.6422 degrees from the ROI center at RA, Dec = 83.6331, 22.0145 7.57107
``` 

(for 30 sources, same place as the other output) but I couldn't find where in the code this is from. I don't even know if it's fermipy or threeML or fermi tools. Any ideas?



