### PR TITLE
np.bool deprecation warning

### DIFF
--- a/threeML/plugins/SpectrumLike.py
+++ b/threeML/plugins/SpectrumLike.py
@@ -150,7 +150,7 @@ class SpectrumLike(PluginPrototype):
         # select channels that were flagged as bad.
 
         self._mask = np.asarray(
-            np.ones(self._observed_spectrum.n_channels), np.bool)
+            np.ones(self._observed_spectrum.n_channels), bool)
 
         # Now create the nuisance parameter for the effective area correction, which is fixed
         # by default. This factor multiplies the model so that it can account for calibration uncertainties on the

--- a/threeML/utils/time_series/event_list.py
+++ b/threeML/utils/time_series/event_list.py
@@ -157,7 +157,7 @@ class EventList(TimeSeries):
             # create phas to check
             phas = np.arange(self._first_channel, self._n_channels)[mask]
 
-            this_mask = np.zeros_like(self._arrival_times, dtype=np.bool)
+            this_mask = np.zeros_like(self._arrival_times, dtype=bool)
 
             for channel in phas:
                 this_mask = np.logical_or(

--- a/threeML/utils/time_series/time_series.py
+++ b/threeML/utils/time_series/time_series.py
@@ -211,7 +211,7 @@ class TimeSeries(object):
         :return:
         """
         if mask is None:
-            mask = np.ones_like(self._polynomials, dtype=np.bool)
+            mask = np.ones_like(self._polynomials, dtype=bool)
 
         total_counts = 0
 
@@ -230,7 +230,7 @@ class TimeSeries(object):
         :return:
         """
         if mask is None:
-            mask = np.ones_like(self._polynomials, dtype=np.bool)
+            mask = np.ones_like(self._polynomials, dtype=bool)
 
         total_counts = 0
 


### PR DESCRIPTION


We should replace `np.bool` with `bool` or `np.bool_` in the code.

**Is your feature request related to a problem? Please describe.**

I'm getting ~15k of  

```
  WARNING DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

in the tests.

We use `np.bool` in only four places in the code:

* https://github.com/threeML/threeML/blob/master/threeML/plugins/SpectrumLike.py#L153
* https://github.com/threeML/threeML/blob/master/threeML/utils/time_series/time_series.py#L214
* https://github.com/threeML/threeML/blob/master/threeML/utils/time_series/time_series.py#L233
* https://github.com/threeML/threeML/blob/master/threeML/utils/time_series/event_list.py#L160

**Describe the solution you'd like**

It should be a quick fix to replace `np.bool` with plain `bool` (which according to the docs should work in most cases),  or `np.bool_`, I'm just not sure which one of the two we need.
