### PR TITLE
Update fermi EventClasses/IRFs

### DIFF
--- a/threeML/plugins/FermipyLike.py
+++ b/threeML/plugins/FermipyLike.py
@@ -14,6 +14,9 @@ from threeML.utils.unique_deterministic_tag import get_unique_deterministic_tag
 from threeML.utils.power_of_two_utils import is_power_of_2
 from threeML.io.package_data import get_path_of_data_file
 from threeML.io.dict_with_pretty_print import DictWithPrettyPrint
+from threeML.io.logging import setup_logger
+
+log = setup_logger(__name__)
 
 __instrument_name = "Fermi LAT (with fermipy)"
 
@@ -25,19 +28,18 @@ __instrument_name = "Fermi LAT (with fermipy)"
 
 
 # A lookup map for the correspondence between IRFS and evclass
+# See https://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_Data/LAT_DP.html#PhotonClassification
 evclass_irf = {
-    2: "P8R2_TRANSIENT100E_V6",
-    4: "P8R2_TRANSIENT100_V6",
-    8: "P8R2_TRANSIENT020E_V6",
-    16: "P8R2_TRANSIENT020_V6",
-    32: "P8R2_TRANSIENT010E_V6",
-    64: "P8R2_TRANSIENT010_V6",
-    128: "P8R2_SOURCE_V6",
-    256: "P8R2_CLEAN_V6",
-    512: "P8R2_ULTRACLEAN_V6",
-    1024: "P8R2_ULTRACLEANVETO_V6",
-    32768: "P8R2_TRANSIENT100S_V6",
-    65536: "P8R2_TRANSIENT015S_V6",
+    8: "P8R3_TRANSIENT020E_V3",
+    16: "P8R3_TRANSIENT020_V3",
+    32: "P8R3_TRANSIENT010E_V3",
+    64: "P8R3_TRANSIENT010_V3",
+    128: "P8R3_SOURCE_V3",
+    256: "P8R3_CLEAN_V3",
+    512: "P8R3_ULTRACLEAN_V3",
+    1024: "P8R3_ULTRACLEANVETO_V3",
+    2048: "P8R3_SOURCEVETO_V3",
+    65536: "P8R3_TRANSIENT015S_V3",
 }
 
 
@@ -55,15 +57,17 @@ def _get_unique_tag_from_configuration(configuration):
 
     for section, keys in keys_for_hash:
 
-        assert section in configuration, (
-            "Configuration lacks section %s, which is required" % section
-        )
+        if not section in configuration:
+            log.critical(
+                "Configuration lacks section %s, which is required" % section
+            )
 
         for key in keys:
 
-            assert key in configuration[section], (
-                "Section %s in configuration lacks key %s, which is required" % key
-            )
+            if not key in configuration[section]:
+                log.critical(
+                    "Section %s in configuration lacks key %s, which is required" % key
+                )
 
             string_to_hash.append("%s" % configuration[section][key])
 
@@ -93,12 +97,15 @@ def _get_fermipy_instance(configuration, likelihood_model):
     # Get IRFS
     irfs = evclass_irf[int(configuration["selection"]["evclass"])]
 
+    log.info(f"Using IRFs {irfs}")
+
     if "gtlike" in configuration and "irfs" in configuration["gtlike"]:
 
-        assert irfs.upper() == configuration["gtlike"]["irfs"].upper(), (
-            "Evclass points to IRFS %s, while you specified %s into he "
-            "configuration" % (irfs, configuration["gtlike"]["irfs"])
-        )
+        if irfs.upper() != configuration["gtlike"]["irfs"].upper():
+            log.critical(
+                "Evclass points to IRFS %s, while you specified %s in the "
+                "configuration" % (irfs, configuration["gtlike"]["irfs"])
+            )
 
     else:
 
@@ -194,7 +201,8 @@ def _get_fermipy_instance(configuration, likelihood_model):
 
             # This is to make sure that all sources are evaluated at the same energies
 
-            assert np.all(energies_keV == this_energies_keV)
+            if not np.all(energies_keV == this_energies_keV):
+                log.critical("All sources should be evaluated at the same energies.")
 
         dnde = point_source(energies_keV)  # ph / (cm2 s keV)
         dnde_per_MeV = dnde * 1000.0  # ph / (cm2 s MeV)
@@ -255,9 +263,10 @@ class FermipyLike(PluginPrototype):
             # Assume this is a file name
             configuration_file = sanitize_filename(fermipy_config)
 
-            assert os.path.exists(fermipy_config), (
-                "Configuration file %s does not exist" % configuration_file
-            )
+            if not os.path.exists(fermipy_config):
+                log.critical(
+                    "Configuration file %s does not exist" % configuration_file
+                )
 
             # Read the configuration
             with open(configuration_file) as f:
@@ -293,12 +302,10 @@ class FermipyLike(PluginPrototype):
         # Now check that the data exists
 
         # As minimum there must be a evfile and a scfile
-        assert (
-            "evfile" in self._configuration["data"]
-        ), "You must provide a evfile in the data section"
-        assert (
-            "scfile" in self._configuration["data"]
-        ), "You must provide a scfile in the data section"
+        if not "evfile" in self._configuration["data"]:
+            log.critical( "You must provide a evfile in the data section" )
+        if not "scfile" in self._configuration["data"]:
+            log.critical( "You must provide a scfile in the data section" )
 
         for datum in self._configuration["data"]:
 
@@ -308,9 +315,8 @@ class FermipyLike(PluginPrototype):
 
             self._configuration["data"][datum] = filename
 
-            assert os.path.exists(
-                self._configuration["data"][datum]
-            ), "File %s (%s) not found" % (filename, datum)
+            if not os.path.exists( self._configuration["data"][datum] ):
+                log.critical( "File %s (%s) not found" % (filename, datum) )
 
         # Prepare the 'fileio' part
         # Save all output in a directory with a unique name which depends on the configuration,
@@ -324,12 +330,11 @@ class FermipyLike(PluginPrototype):
         self._configuration["fileio"] = {"outdir": self._unique_id}
 
         # Ensure that there is a complete definition of a Region Of Interest (ROI)
-        assert ("ra" in self._configuration["selection"]) and (
-            "dec" in self._configuration["selection"]
-        ), (
-            "You have to provide 'ra' and 'dec' in the 'selection' section of the configuration. Source name "
-            "resolution, as well as Galactic coordinates, are not currently supported"
-        )
+        if not (("ra" in self._configuration["selection"]) and ("dec" in self._configuration["selection"])):
+            log.critical(
+                "You have to provide 'ra' and 'dec' in the 'selection' section of the configuration. Source name "
+                "resolution, as well as Galactic coordinates, are not currently supported"
+            )
 
         # This is empty at the beginning, will be instanced in the set_model method
         self._gta = None
@@ -360,8 +365,10 @@ class FermipyLike(PluginPrototype):
         evfile = str(sanitize_filename(evfile) )
         scfile = str(sanitize_filename(scfile) )
 
-        assert os.path.exists(evfile), "The provided evfile %s does not exist" % evfile
-        assert os.path.exists(scfile), "The provided scfile %s does not exist" % scfile
+        if not os.path.exists(evfile):
+            log.critical( "The provided evfile %s does not exist" % evfile )
+        if not os.path.exists(scfile):
+            log.critical( "The provided scfile %s does not exist" % scfile )
 
         basic_config["data"]["evfile"] = evfile
         basic_config["data"]["scfile"] = scfile
@@ -369,12 +376,14 @@ class FermipyLike(PluginPrototype):
         ra = float(ra)
         dec = float(dec)
 
-        assert 0 <= ra <= 360, (
-            "The provided R.A. (%s) is not valid. Should be 0 <= ra <= 360.0" % ra
-        )
-        assert -90 <= dec <= 90, (
-            "The provided Dec (%s) is not valid. Should be -90 <= dec <= 90.0" % dec
-        )
+        if not (( 0 <= ra) and ( ra <= 360 )):
+            log.critical(
+                "The provided R.A. (%s) is not valid. Should be 0 <= ra <= 360.0" % ra
+            )
+        if not ((-90 <= dec) and (dec <= 90)):
+            log.critical (
+                "The provided Dec (%s) is not valid. Should be -90 <= dec <= 90.0" % dec
+            )
 
         basic_config["selection"]["ra"] = ra
         basic_config["selection"]["dec"] = dec
@@ -386,10 +395,11 @@ class FermipyLike(PluginPrototype):
         basic_config["selection"]["emax"] = emax
 
         zmax = float(zmax)
-        assert 0.0 <= zmax <= 180.0, (
-            "The provided Zenith angle cut (zmax = %s) is not valid. "
-            "Should be 0 <= zmax <= 180.0" % zmax
-        )
+        if not (( 0.0 <= zmax) and (zmax <= 180.0)):
+            log.critical(
+                "The provided Zenith angle cut (zmax = %s) is not valid. "
+                "Should be 0 <= zmax <= 180.0" % zmax
+            )
 
         basic_config["selection"]["zmax"] = zmax
 
@@ -401,7 +411,8 @@ class FermipyLike(PluginPrototype):
         basic_config["selection"]["tmax"] = tmax
 
         evclass = int(evclass)
-        assert is_power_of_2(evclass), "The provided evclass is not a power of 2."
+        if not is_power_of_2(evclass):
+            log.critical( "The provided evclass is not a power of 2." )
 
         basic_config["selection"]["evclass"] = evclass
 
@@ -430,10 +441,11 @@ class FermipyLike(PluginPrototype):
     @property
     def gta(self):
 
-        assert self._gta is not None, (
-            "You have to perform a fit or a bayesian analysis before accessing the "
-            "gta object"
-        )
+        if self._gta is None:
+            log.warning(
+                "You have to perform a fit or a bayesian analysis before accessing the "
+                "gta object. Returning None"
+            )
 
         return self._gta
 

--- a/threeML/test/test_FermipyLike.py
+++ b/threeML/test/test_FermipyLike.py
@@ -14,7 +14,7 @@ skip_if_fermipy_is_not_available = pytest.mark.skipif(
 
 @skip_if_internet_is_not_available
 @skip_if_fermipy_is_not_available
-@pytest.mark.xfail
+#@pytest.mark.xfail
 def test_FermipyLike():
     from threeML.plugins.FermipyLike import FermipyLike
 


### PR DESCRIPTION
Make sure we're using the most recent event class names/IRFs (see https://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_Data/LAT_DP.html#PhotonClassification ).

Also switched the fermipy plugin to use the logger. 