### PR TITLE
Allow specification of parameters to be plotted in analysis_results.corner_plot

### DIFF
--- a/threeML/test/test_analysis_results.py
+++ b/threeML/test/test_analysis_results.py
@@ -338,6 +338,8 @@ def test_corner_plotting(xy_completed_bayesian_analysis):
 
     ar.corner_plot()
 
+    ar.corner_plot(components = [*ar._free_parameters.keys()][0:2])
+
 
 def test_one_free_parameter_input_output():
 


### PR DESCRIPTION
Allows parameters to be specified when creating the corner plot. This essentially allows creation of a custom contour plot similar to [XSPEC's plot contour](https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSplot.html).

e.g. in a results objects with >2 parameters, you could choose a subset of those to be plotted instead of all parameters.
