### PR TITLE
make warning text for infinite likelihood useful

### DIFF
--- a/threeML/bayesian/sampler_base.py
+++ b/threeML/bayesian/sampler_base.py
@@ -397,9 +397,15 @@ class SamplerBase(with_metaclass(abc.ABCMeta, object)):
 
         if not np.isfinite(log_like):
             # Issue warning
+            # for some samplers (like multinest) the
+            keys = self._likelihood_model.free_parameters.keys()
+            params = [
+                f"{key}: {self._likelihood_model.free_parameters[key].value}"
+                for key in keys
+            ]
 
             log.warning(
-                "Likelihood value is infinite for parameters %s" % trial_values,
+                f"Likelihood value is infinite for parameters: {params}"
             )
 
             return -np.inf


### PR DESCRIPTION
The "Likelihood value is infinite for parameters: {trial_values}" warning in sampler_base produced not useful output because the trial_values (at least for multinest) are some ctype variables that were not printed out in a human readable way. So I changed that, to make the warning output useful.