### PR TITLE
fix for pandas version 1.4

### DIFF
--- a/threeML/__init__.py
+++ b/threeML/__init__.py
@@ -2,7 +2,7 @@
 # Indeed, if no DISPLAY variable is set, matplotlib 2.0 crashes (at the moment, 05/26/2017)
 import pandas as pd
 
-pd.set_option("max_columns", None)
+pd.set_option("display.max_columns", None)
 
 import os
 import traceback


### PR DESCRIPTION
Small fix. Needed due to the new available option "styler.render.max_columns" in panda version 1.4. Due to this pd.set_option("max_columns", None) is not clear anymore which option is meant and this caused an error when starting 3ML.