### PR TITLE
Fix division by zero issue

### DIFF
--- a/threeML/plugins/SpectrumLike.py
+++ b/threeML/plugins/SpectrumLike.py
@@ -638,19 +638,14 @@ class SpectrumLike(PluginPrototype):
 
                 log.debug("this is a normal background observation")
 
-                self._background_scale_factor = (
-                    self._background_spectrum.scale_factor
-                )
+                self._background_scale_factor = (self._background_spectrum.scale_factor)
+                
                 self._background_exposure = self._background_spectrum.exposure
 
-            self._area_ratio = old_div(
-                self._observed_spectrum.scale_factor,
-                self._background_scale_factor,
-            )
+            self._area_ratio = float(self._observed_spectrum.scale_factor) / float(self._background_scale_factor)
 
-            self._exposure_ratio = old_div(
-                self._observed_spectrum.exposure, self._background_exposure
-            )
+            self._exposure_ratio = float(self._observed_spectrum.exposure) / float(self._background_exposure)
+            
 
         self._total_scale_factor = self._area_ratio * self._exposure_ratio
 


### PR DESCRIPTION
If scale factor or exposure were integers, the use of old_div could create an unexpected division by zero issue. Using the standard python division and forcing them to be floats fixes the problem.