### PR TITLE
Switch fermipy test to minuit minimizer

### DIFF
--- a/threeML/test/test_FermipyLike.py
+++ b/threeML/test/test_FermipyLike.py
@@ -199,7 +199,7 @@ def test_FermipyLike_fromDisk():
 
     jl = JointLikelihood(model, data)
 
-    jl.set_minimizer("ROOT")
+    jl.set_minimizer("minuit")
 
 
     res = jl.fit()


### PR DESCRIPTION
Future fermitools won't have root as a dependency anymore. 