### PR TITLE
"Unhashable" error fix

### DIFF
--- a/threeML/utils/data_builders/fermi/lat_transient_builder.py
+++ b/threeML/utils/data_builders/fermi/lat_transient_builder.py
@@ -82,7 +82,7 @@ class LATLikelihoodParameter(object):
 
         # make sure that the value set is allowed
         if self._allowed_values is not None:
-            assert self._current_value in self._allowed_values, 'The value of %s is not in %s' % (self._name, self._allowed_values )
+            assert self._current_value in set(self._allowed_values), 'The value of %s is not in %s' % (self._name, self._allowed_values )
 
         # construct the class
 


### PR DESCRIPTION
One of the students here was getting an error about `self._allowed_values` (type `odict_keys`) not being hashable. This fixes it. 