### PR TITLE
Backround normalization as nuisance parameters for FermipyLike

### DIFF
--- a/docs/md_docs/slow_execute/Fermipy_LAT.md
+++ b/docs/md_docs/slow_execute/Fermipy_LAT.md
@@ -6,7 +6,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.13.8
+      jupytext_version: 1.14.1
   kernelspec:
     display_name: Python 3 (ipykernel)
     language: python
@@ -178,6 +178,21 @@ data = DataList(LAT)
 jl = JointLikelihood(model, data)
 ```
 
+The normalization factors of the LAT background components are included in the models as nuisance parameters. They are only added during the previous step (during the model assignment). Let's display them:
+
+```python
+for k, v in LAT.nuisance_parameters.items():
+    print (k, ":", v)
+```
+
+We will fix the isotropic BG as we are not sensitive to it with this dataset. We will also fix one more weak source.
+
+```python
+model.LAT_isodiff_Normalization.fix = True
+model._4FGL_J0544d4p2238.spectrum.main.Powerlaw.K.fix = True
+model.display()
+```
+
 ### Performing the fit
 
 ```python
@@ -210,8 +225,8 @@ Or we might want to produce a contour plot
 
 ```python
 res = jl.get_contours(
-    'PSR_J0534p2200.spectrum.main.Super_cutoff_powerlaw.K',0.7e-13,1.3e-13, 20,
-    'PSR_J0534p2200.spectrum.main.Super_cutoff_powerlaw.index',-2.0,-1.6, 20
+    'PSR_J0534p2200.spectrum.main.Super_cutoff_powerlaw.K',1.6e-13,2.2e-13, 20,
+    'PSR_J0534p2200.spectrum.main.Super_cutoff_powerlaw.index',-2.0,-1.7, 20
 )
 ```
 
@@ -241,7 +256,7 @@ All the plots are saved in the output directory as png files:
 We can also plot the resulting model:
 
 ```python
-energies=sp.logspace(1,8,100) *u.MeV
+energies=sp.logspace(1,6,100) *u.MeV
 fig, ax=plt.subplots()
 # we only want to visualize the relevant sources...
 src_to_plot=['Crab','PSR_J0534p2200']
@@ -265,7 +280,7 @@ ax.legend(loc=0,frameon=False)
 
 ax.set_xlabel("Energy (MeV)")
 ax.set_ylabel(r"Flux (ph cm$^{-2}$ s$^{-1}$ keV$^{-1}$")
-ax.set_ylim([1e-20,1e-3])
+ax.set_ylim([1e-18,1e-8])
 
 #show the plot
 fig
@@ -273,12 +288,12 @@ fig
 
 We can also do a bayesian analysis.
 
-This will set priors based on the current defined min-max (log-uniform or uniform)
 
+This will set priors based on the current defined min-max (log-uniform or uniform). 
 
 ```python
-
 for param in model.free_parameters.values():
+
     if param.has_transformation():
         param.set_uninformative_prior( Log_uniform_prior )
     else:
@@ -290,6 +305,13 @@ for param in model.free_parameters.values():
 shutil.rmtree(fermipy_output_directory)
 
 bayes = BayesianAnalysis(model, data)
+```
+
+Take care of the nuisance parameters `LAT_isodiff_Normalization` and `LAT_galdiff_Prefactor`, which are only created during the previous step.
+
+```python
+model.LAT_isodiff_Normalization.fix = True
+model.LAT_galdiff_Prefactor.set_uninformative_prior( Log_uniform_prior )
 ```
 
 ```python

--- a/threeML/minimizer/minimization.py
+++ b/threeML/minimizer/minimization.py
@@ -713,7 +713,7 @@ class Minimizer(object):
             # so we need to make sure that the parameter has the best fit value)
             parameters_list[i]._set_internal_value(value)
 
-            if covariance_matrix is not None:
+            if (covariance_matrix is not None) and (covariance_matrix.ndim > 1):
 
                 element = covariance_matrix[i, i]
 
@@ -746,7 +746,7 @@ class Minimizer(object):
 
         self._correlation_matrix = np.zeros_like(self._covariance_matrix)
 
-        if covariance_matrix is not None:
+        if (covariance_matrix is not None) and (covariance_matrix.ndim > 1):
 
             for i in range(self.Npar):
 

--- a/threeML/plugins/FermipyLike.py
+++ b/threeML/plugins/FermipyLike.py
@@ -7,6 +7,10 @@ import yaml
 import astropy.io.fits as fits
 from astropy.stats import circmean
 from astropy import units as u
+import collections
+
+from astromodels import Model, Parameter
+from astromodels.core import parameter_transformation
 
 from threeML.exceptions.custom_exceptions import custom_warnings
 from threeML.io.file_utils import sanitize_filename
@@ -225,9 +229,6 @@ def _get_fermipy_instance(configuration, likelihood_model):
         likelihood_model.point_sources.values()
     ):  # type: astromodels.PointSource
 
-        # Fix this source, so fermipy will not optimize by itself the parameters
-        gta.free_source(point_source.name, False)
-
         # This will substitute the current spectrum with a FileFunction with the same shape and flux
         gta.set_source_spectrum(point_source.name, "FileFunction", update_source=False)
 
@@ -256,9 +257,6 @@ def _get_fermipy_instance(configuration, likelihood_model):
     for extended_source in list(
         likelihood_model.extended_sources.values()
     ):  # type: astromodels.ExtendedSource
-
-        # Fix this source, so fermipy will not optimize by itself the parameters
-        gta.free_source(extended_source.name, False)
 
         # This will substitute the current spectrum with a FileFunction with the same shape and flux
         gta.set_source_spectrum(extended_source.name, "FileFunction", update_source=False)
@@ -407,6 +405,9 @@ class FermipyLike(PluginPrototype):
 
         # This is empty at the beginning, will be instanced in the set_model method
         self._gta = None
+ 
+        self.set_inner_minimization(True)
+
 
     @staticmethod
     def get_basic_config(
@@ -532,7 +533,11 @@ class FermipyLike(PluginPrototype):
             self._configuration, likelihood_model_instance
         )
         self._update_model_in_fermipy( update_dictionary = True, force_update = True)
-        
+            
+        # Build the list of the nuisance parameters
+        new_nuisance_parameters = self._set_nuisance_parameters()
+        self.update_nuisance_parameters(new_nuisance_parameters)
+
 
     def _update_model_in_fermipy(self, update_dictionary = False, delta = 0.0, force_update = False):
 
@@ -629,7 +634,6 @@ class FermipyLike(PluginPrototype):
             # (HF: Not sure who wrote the above but I think sometimes we do want to update fermipy dictionaries.)
             self._gta.set_source_dnde(extended_source.name, dnde_MeV, update_source = update_dictionary)
 
-
     def get_log_like(self):
         """
         Return the value of the log-likelihood with the current values for the
@@ -639,8 +643,16 @@ class FermipyLike(PluginPrototype):
         # Update all sources on the fermipy side
         self._update_model_in_fermipy()
 
-        # Get value of the log likelihood
+        #update nuisance parameters
+        if self._fit_nuisance_params:
 
+            for parameter in self.nuisance_parameters:
+                self.set_nuisance_parameter_value(parameter, self.nuisance_parameters[parameter].value)
+
+            #self.like.syncSrcParams()
+
+
+        # Get value of the log likelihood
         try:
 
             value = self._gta.like.logLike.value()
@@ -659,7 +671,26 @@ class FermipyLike(PluginPrototype):
         particular detector. If there are no nuisance parameters, simply return the
         logLike value.
         """
+        
         return self.get_log_like()
+
+    def set_inner_minimization(self, flag: bool) -> None:
+
+        """
+        Turn on the minimization of the internal Fermi
+        parameters
+
+        :param flag: turing on and off the minimization  of the Fermipy internal parameters
+        :type flag: bool
+        :returns:
+
+        """
+        self._fit_nuisance_params: bool = bool(flag)
+
+        for parameter in self.nuisance_parameters:
+
+            self.nuisance_parameters[parameter].free = self._fit_nuisance_params
+
 
     def get_number_of_data_points(self):
         """
@@ -679,3 +710,58 @@ class FermipyLike(PluginPrototype):
             num = num * np.sum(self.geom.npix)
             
         return num
+
+    def _set_nuisance_parameters(self):
+
+        # Get the list of the sources
+        sources = list(self.gta.roi.get_sources() )
+        sources = [s.name for s in sources if "diff" in s.name]
+        
+
+        bg_param_names = []
+        nuisance_parameters = collections.OrderedDict()
+
+        for src_name in sources:
+
+            if self._fit_nuisance_params:
+                self.gta.free_norm(src_name)
+    
+            pars = self.gta.get_free_source_params(src_name)
+                        
+            for par in pars:
+            
+                thisName = f"{self.name}_{src_name}_{par}"
+                bg_param_names.append(thisName)
+
+                thePar = self.gta._get_param( src_name, par)
+
+                value = thePar["value"] * thePar["scale"]
+
+                nuisance_parameters[thisName] = Parameter(
+                    thisName,
+                    value,
+                    min_value=thePar["min"],
+                    max_value=thePar["max"],
+                    delta=0.01*value,
+                    transformation=parameter_transformation.get_transformation("log10")
+                )
+
+                nuisance_parameters[thisName].free = self._fit_nuisance_params
+                
+                log.debug(f"Added nuisance parameter {nuisance_parameters[thisName]}")
+
+        return nuisance_parameters
+
+    def _split_nuisance_parameter(self, param_name):
+
+        tokens = param_name.split("_")
+        pname = tokens[-1]
+        src_name = "_".join(tokens[1:-1])
+        
+        return src_name, pname
+        
+    def set_nuisance_parameter_value(self, paramName, value):
+
+        srcName, parName = self._split_nuisance_parameter(paramName)
+        self.gta.set_parameter(srcName, parName, value, scale = 1, update_source=True)
+

--- a/threeML/plugins/FermipyLike.py
+++ b/threeML/plugins/FermipyLike.py
@@ -763,5 +763,5 @@ class FermipyLike(PluginPrototype):
     def set_nuisance_parameter_value(self, paramName, value):
 
         srcName, parName = self._split_nuisance_parameter(paramName)
-        self.gta.set_parameter(srcName, parName, value, scale = 1, update_source=True)
+        self.gta.set_parameter(srcName, parName, value, scale = 1, update_source=False)
 

--- a/threeML/test/test_FermipyLike.py
+++ b/threeML/test/test_FermipyLike.py
@@ -59,6 +59,11 @@ def test_FermipyLike_fromVO():
 
     assert len(model.free_parameters) == 4
 
+    #fix another weak source
+    model._4FGL_J0544d4p2238.spectrum.main.Powerlaw.K.fix = True
+
+    assert len(model.free_parameters) == 3
+
     # Download data from Jan 01 2010 to Jan 2 2010
 
     tstart = "2010-01-01 00:00:00"
@@ -104,7 +109,19 @@ def test_FermipyLike_fromVO():
     # Here is where the fermipy processing happens (the .setup method)
     jl = JointLikelihood(model, data)
 
+    jl.set_minimizer("minuit")
+
+    #check that nuisance parameters have been added and fix normalization of isodiff BG (not sensitive)
+    assert len(model.free_parameters) == 5
+    model.LAT_isodiff_Normalization.fix = True
+    assert len(model.free_parameters) == 4
+
     res = jl.fit()
+
+    #make sure galactic diffuse fit worked
+    assert np.isclose(model.LAT_galdiff_Prefactor.value, 1.0, rtol=0.2, atol=0.2)
+    
+    
 
 @skip_if_internet_is_not_available
 @skip_if_fermipy_is_not_available
@@ -151,6 +168,11 @@ def test_FermipyLike_fromDisk():
 
 
     assert len(model.free_parameters) == 4
+
+    #fix another weak source
+    model._4FGL_J0544d4p2238.spectrum.main.Powerlaw.K.fix = True
+
+    assert len(model.free_parameters) == 3
 
     # Download data from Jan 01 2010 to Jan 2 2010
 
@@ -201,5 +223,13 @@ def test_FermipyLike_fromDisk():
 
     jl.set_minimizer("minuit")
 
+    #check that nuisance parameters have been added and fix normalization of isodiff BG (not sensitive)
+    assert len(model.free_parameters) == 5
+    model.LAT_isodiff_Normalization.fix = True
+    assert len(model.free_parameters) == 4
 
     res = jl.fit()
+
+    #make sure galactic diffuse fit worked
+    assert np.isclose(model.LAT_galdiff_Prefactor.value, 1.0, rtol=0.2, atol=0.2)
+


### PR DESCRIPTION
Added the normalization of the galactic and isotropic diffuse BG to the fermipy plugin as nuisance parameters. They are free by default.

@omodei please take a look!

One thing I don't like is how priors are handled for the bayesian analysis. For other model parameters, the user must assign a prior *before* creating the `BayesianAnalysis` object. However, the nuisance parameters are only created during that step, and we have to remember to add a prior afterwards. I wonder if we should add a default prior and/or throw a warning? Although I'm not sure how we would know inside `set_model` if we're creating a bayesian or likelihood analysis...