### PR TITLE
Quick fix: missing comma

### DIFF
--- a/threeML/catalogs/FermiLAT.py
+++ b/threeML/catalogs/FermiLAT.py
@@ -135,7 +135,7 @@ class FermiLATSourceCatalog(VirtualObservatoryCatalog):
         else:
 
             new_table = table[
-                "name", "source_type", "short_source_type" "ra", "dec", "assoc_name", "tevcat_assoc"
+                "name", "source_type", "short_source_type", "ra", "dec", "assoc_name", "tevcat_assoc"
             ]
 
             return new_table.group_by("name")


### PR DESCRIPTION
KeyError due to missing comma:

```
File "/Users/xboluna/opt/miniconda3/envs/threeML/lib/python3.7/site-packages/threeML/catalogs/VirtualObservatoryCatalog.py", line 223, in query_sources
    out = self.apply_format(table)
  File "/Users/xboluna/opt/miniconda3/envs/threeML/lib/python3.7/site-packages/threeML/catalogs/FermiLAT.py", line 138, in apply_format
    "name", "source_type", "short_source_type" "ra", "dec", "assoc_name", "tevcat_assoc"
  File "/Users/xboluna/opt/miniconda3/envs/threeML/lib/python3.7/site-packages/astropy/table/table.py", line 1873, in __getitem__
    out = self.__class__([self[x] for x in item],
  File "/Users/xboluna/opt/miniconda3/envs/threeML/lib/python3.7/site-packages/astropy/table/table.py", line 1873, in <listcomp>
    out = self.__class__([self[x] for x in item],
  File "/Users/xboluna/opt/miniconda3/envs/threeML/lib/python3.7/site-packages/astropy/table/table.py", line 1867, in __getitem__
    return self.columns[item]
  File "/Users/xboluna/opt/miniconda3/envs/threeML/lib/python3.7/site-packages/astropy/table/table.py", line 246, in __getitem__
    return OrderedDict.__getitem__(self, item)
KeyError: 'short_source_typera'
```