### PR TITLE
Send logs to stderr by default

### DIFF
--- a/threeML/__init__.py
+++ b/threeML/__init__.py
@@ -21,10 +21,10 @@ except ImportError:
 
 from pathlib import Path
 
-from threeML.io.logging import setup_logger
-
 # Import everything from astromodels
 from astromodels import *
+
+from .io.logging import setup_logger
 
 from .config import (
     threeML_config,

--- a/threeML/config/config_utils.py
+++ b/threeML/config/config_utils.py
@@ -5,13 +5,15 @@ from typing import Any, Dict, Optional
 from omegaconf import OmegaConf
 from omegaconf.dictconfig import DictConfig
 from rich.tree import Tree
-from threeML.io.logging import setup_logger
 from threeML.io.package_data import get_path_of_user_config
 
 from .config import threeML_config
 
-log = setup_logger(__name__)
-
+# FIXME: These lines were moved to local imports withing functions since
+#  they were causing a circular import. The config module needs the logging setup,
+#  and the logging setup needs the config module.
+#from threeML.io.logging import setup_logger
+#log = setup_logger(__name__)
 
 def recurse_dict(d, tree):
 
@@ -64,6 +66,8 @@ def show_configuration(sub_menu: Optional[str] = None):
 
             msg = f"{sub_menu} is not in the threeml configuration"
 
+            from threeML.io.logging import setup_logger
+            log = setup_logger(__name__)
             log.error(msg)
 
             raise AssertionError(msg)
@@ -111,6 +115,10 @@ def get_value(name, user_value, par_type, config_value):
     :param config_value: value in config
     :returns: parameter value
     """
+
+    from threeML.io.logging import setup_logger
+    log = setup_logger(__name__)
+
     if user_value is not None:
         value = user_value
     else:

--- a/threeML/io/logging.py
+++ b/threeML/io/logging.py
@@ -118,7 +118,7 @@ _theme["logging.level.warning"] = f"{astromodels_config.logging.warn_style}"
 # mytheme = Theme().read(_get_data_file_path("log_theme.ini"))
 mytheme = Theme(_theme)
 
-console = Console(theme=mytheme)
+console = Console(theme=mytheme, stderr=True)
 
 
 threeML_console_log_handler = RichHandler(


### PR DESCRIPTION
Python's builtin logging library prints by default to stdout, not stderr. This is the convention since it allows you to easily separate the applications output from the logs. This is, for example, useful when working on larger pipelines, where the logs and output are usually redirected to different places.

This is related to this other issue in Rich, which threeML uses:
https://github.com/Textualize/rich/issues/2022

While the maintainer hasn't changed the default to stderr, the thread has multiple arguments from various developers of why this should be the default. ThreeML uses a custom `Console` when calling `RichHandler`, so the Rich default doesn't matter, but I thought it was still related.

In principle, just adding the flag `stderr=True` during the `Console` instantiation should had been enough, but the log were still being outputted to stdout.

The problem was that the main `__init__` is importing everything from `astromodels`, including the astromodel's `setup_logger`, which was shadowing theeML's `setup_logger`.

Fixing the order of the imports revealed a circular import, which was preventing importing threeML at all. The `io/logging` moduled needed the `config` module to configure the logger, and the `config` module needed `io/logging` to create its own logs. I patched this by moving the `setup_logger` import in `config` to local import within the functions where it was needed.

While this patch worked for now to achieve the initial goal of using logging to stderr by default, a circular import is usually a symptom telling you that there's something in the code design that needs to changed. In this case, I think the way to go to solve this circular import is to not configure the logging within 3ML at all. This is also the recommended way to use the logging library. I opened the issue #647 about this, which I can address in a separate PR. 

The equivalent PR for astromodels is: https://github.com/threeML/astromodels/pull/217