### PR TITLE
Remove Python2 compatibility Code

### DIFF
--- a/threeML/analysis_results.py
+++ b/threeML/analysis_results.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function
-
 import collections
 import datetime
 import functools
@@ -22,7 +20,6 @@ from astromodels.core.my_yaml import my_yaml
 from astromodels.core.parameter import Parameter
 from corner import corner
 from matplotlib import colormaps
-from past.utils import old_div
 from rich.console import Console
 
 from threeML import __version__
@@ -677,8 +674,8 @@ class _AnalysisResults(object):
                 variance_j = covariance[j, j]
 
                 if variance_i * variance_j > 0:
-                    correlation_matrix[i, j] = old_div(
-                        covariance[i, j], (math.sqrt(variance_i * variance_j))
+                    correlation_matrix[i, j] = covariance[i, j] / (
+                        math.sqrt(variance_i * variance_j)
                     )
 
                 else:
@@ -1495,7 +1492,7 @@ class BayesianResults(_AnalysisResults):
 
         binsize = 2 * iqr * pow(len(data), -1 / 3.0)
 
-        nbins = np.ceil(old_div((max(data) - min(data)), binsize))
+        nbins = np.ceil((np.max(data) - min(data)) / binsize)
 
         return nbins
 

--- a/threeML/catalogs/Fermi.py
+++ b/threeML/catalogs/Fermi.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import math
 import re
 from builtins import map, str
@@ -16,7 +14,6 @@ from astromodels.functions import (
     Super_cutoff_powerlaw,
 )
 from astromodels.utils.angular_distance import angular_distance
-from past.utils import old_div
 
 from threeML.config.config import threeML_config
 from threeML.io.dict_with_pretty_print import DictWithPrettyPrint
@@ -347,7 +344,7 @@ class FermiGBMBurstCatalog(VirtualObservatoryCatalog):
         amp = row[primary_string + "ampl"]
 
         # need to correct epeak to e cut
-        ecut = old_div(epeak, (2 - index))
+        ecut = epeak / (2 - index)
 
         cpl = Cutoff_powerlaw()
 
@@ -638,7 +635,7 @@ def _get_point_source_from_3fgl(fgl_name, catalog_entry, fix=False):
             this_spectrum.K.value / 1000.0,
             this_spectrum.K.value * 1000,
         )
-        this_spectrum.xc = a ** (old_div(-1.0, b)) * u.MeV
+        this_spectrum.xc = a ** (-1.0 / b) * u.MeV
         this_spectrum.xc.fix = fix
 
     else:

--- a/threeML/catalogs/FermiGBM.py
+++ b/threeML/catalogs/FermiGBM.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy
 from astromodels import (
     Band,
@@ -9,7 +7,6 @@ from astromodels import (
     Powerlaw,
     SmoothlyBrokenPowerLaw,
 )
-from past.utils import old_div
 
 from threeML.config.config import threeML_config
 from threeML.io.dict_with_pretty_print import DictWithPrettyPrint
@@ -314,7 +311,7 @@ class FermiGBMBurstCatalog(VirtualObservatoryCatalog):
         amp = row[primary_string + "ampl"]
 
         # need to correct epeak to e cut
-        ecut = old_div(epeak, (2 - index))
+        ecut = epeak / (2 - index)
 
         cpl = Cutoff_powerlaw()
 

--- a/threeML/catalogs/FermiLAT.py
+++ b/threeML/catalogs/FermiLAT.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import re
 from builtins import map, str
 

--- a/threeML/catalogs/FermiLLE.py
+++ b/threeML/catalogs/FermiLLE.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from threeML.config.config import threeML_config
 from threeML.io.get_heasarc_table_as_pandas import get_heasarc_table_as_pandas
 from threeML.io.logging import setup_logger

--- a/threeML/catalogs/Swift.py
+++ b/threeML/catalogs/Swift.py
@@ -7,15 +7,12 @@ from builtins import map, range, str
 import astropy.table as astro_table
 import numpy as np
 import pandas as pd
-from future import standard_library
 
 from threeML.catalogs.VirtualObservatoryCatalog import VirtualObservatoryCatalog
 from threeML.config.config import threeML_config
 from threeML.io.get_heasarc_table_as_pandas import get_heasarc_table_as_pandas
 from threeML.io.logging import setup_logger
 from threeML.io.rich_display import display
-
-standard_library.install_aliases()
 
 
 log = setup_logger(__name__)

--- a/threeML/catalogs/catalog_utils.py
+++ b/threeML/catalogs/catalog_utils.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import os
 import os.path
 import re

--- a/threeML/classicMLE/joint_likelihood.py
+++ b/threeML/classicMLE/joint_likelihood.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function
-
 import collections
 import sys
 from builtins import object, range, zip
@@ -11,7 +9,6 @@ import scipy.optimize
 import scipy.stats
 from astromodels import Model, ModelAssertionViolation, clone_model
 from matplotlib import colormaps
-from past.utils import old_div
 
 from threeML.analysis_results import MLEResults
 from threeML.config.config import threeML_config
@@ -800,13 +797,11 @@ class JointLikelihood(object):
                     do_log = (True,)
                     lower = (
                         center
-                        * (1.0 + old_div(res["negative_error"][param], center))
-                        ** n_sigma
+                        * (1.0 + res["negative_error"][param] / center) ** n_sigma
                     )
                     upper = (
                         center
-                        * (1.0 + old_div(res["positive_error"][param], center))
-                        ** n_sigma
+                        * (1.0 + res["positive_error"][param] / center) ** n_sigma
                     )
 
                 lower = max(self.likelihood_model[param].bounds[0], lower)
@@ -837,13 +832,11 @@ class JointLikelihood(object):
                     do_log = (True, False)
                     lower_1 = (
                         center_1
-                        * (1.0 + old_div(res["negative_error"][param_1], center_1))
-                        ** n_sigma
+                        * (1.0 + res["negative_error"][param_1] / center_1) ** n_sigma
                     )
                     upper_1 = (
                         center_1
-                        * (1.0 + old_div(res["positive_error"][param_1], center_1))
-                        ** n_sigma
+                        * (1.0 + res["positive_error"][param_1] / center_1) ** n_sigma
                     )
 
                 lower_1 = max(self.likelihood_model[param_1].bounds[0], lower_1)
@@ -866,12 +859,12 @@ class JointLikelihood(object):
                         do_log = (do_log[0], True)
                         lower_2 = (
                             center_2
-                            * (1.0 + old_div(res["negative_error"][param_2], center_2))
+                            * (1.0 + res["negative_error"][param_2] / center_2)
                             ** n_sigma
                         )
                         upper_2 = (
                             center_2
-                            * (1.0 + old_div(res["positive_error"][param_2], center_2))
+                            * (1.0 + res["positive_error"][param_2] / center_2)
                             ** n_sigma
                         )
 

--- a/threeML/config/config_utils.py
+++ b/threeML/config/config_utils.py
@@ -10,10 +10,11 @@ from threeML.io.package_data import get_path_of_user_config
 from .config import threeML_config
 
 # FIXME: These lines were moved to local imports withing functions since
-#  they were causing a circular import. The config module needs the logging setup,
-#  and the logging setup needs the config module.
-#from threeML.io.logging import setup_logger
-#log = setup_logger(__name__)
+# they were causing a circular import. The config module needs the logging setup,
+# and the logging setup needs the config module.
+# from threeML.io.logging import setup_logger
+# log = setup_logger(__name__)
+
 
 def recurse_dict(d, tree):
     for k, v in d.items():
@@ -54,9 +55,9 @@ def show_configuration(sub_menu: Optional[str] = None):
 
         else:
             msg = f"{sub_menu} is not in the threeml configuration"
-            
+
             from threeML.io.logging import setup_logger
-  
+
             log = setup_logger(__name__)
             log.error(msg)
 

--- a/threeML/io/dict_with_pretty_print.py
+++ b/threeML/io/dict_with_pretty_print.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import collections
 
 import yaml

--- a/threeML/io/download_from_ftp.py
+++ b/threeML/io/download_from_ftp.py
@@ -4,11 +4,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-from future import standard_library
-
 from threeML.utils.progress_bar import tqdm
-
-standard_library.install_aliases()
 
 
 def download_file_from_ftp(ftp_url, destination_directory):

--- a/threeML/io/fits_file.py
+++ b/threeML/io/fits_file.py
@@ -1,6 +1,5 @@
 import astropy.units as u
 import numpy as np
-import six
 from astropy.io import fits
 from importlib.metadata import version
 
@@ -139,7 +138,7 @@ class FITSExtension(object):
 
                 units = str(test_value.unit)
 
-            elif isinstance(test_value, six.string_types):
+            elif isinstance(test_value, str):
                 # Get maximum length, but make 1 as minimum length so if the column is
                 # completely made up of empty string we still can work
 

--- a/threeML/io/network.py
+++ b/threeML/io/network.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import socket
 

--- a/threeML/io/plotting/data_residual_plot.py
+++ b/threeML/io/plotting/data_residual_plot.py
@@ -1,7 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.ticker import MaxNLocator
-from past.utils import old_div
 
 from threeML.config.config import threeML_config
 from threeML.io.logging import setup_logger
@@ -145,7 +144,7 @@ class ResidualPlot:
 
         step_plot(
             np.asarray(list(zip(xmin, xmax))),
-            old_div(y, xwidth),
+            y / xwidth,
             self._data_axis,
             label=label,
             **kwargs,

--- a/threeML/io/plotting/light_curve_plots.py
+++ b/threeML/io/plotting/light_curve_plots.py
@@ -1,6 +1,5 @@
 import matplotlib.pyplot as plt
 import numpy as np
-from past.utils import old_div
 
 from threeML.config.config import threeML_config
 from threeML.io.package_data import get_path_of_data_file
@@ -30,9 +29,9 @@ def binned_light_curve_plot(
     """
     fig, ax = plt.subplots()
 
-    top = max(old_div(cnts[width > 0], width[width > 0])) * 1.2
+    top = max(cnts[width > 0] / width[width > 0]) * 1.2
 
-    min_cnts = min(old_div(cnts[cnts > 0], width[cnts > 0])) * 0.95
+    min_cnts = min(cnts[cnts > 0] / width[cnts > 0]) * 0.95
     bottom = min_cnts
     mean_time = np.mean(time_bins, axis=1)
 
@@ -70,7 +69,7 @@ def binned_light_curve_plot(
             for mask in all_masks[1:]:
                 step_plot(
                     time_bins[mask],
-                    old_div(cnts[mask], width[mask]),
+                    cnts[mask] / width[mask],
                     ax,
                     color=selection_color,
                     fill=True,
@@ -79,7 +78,7 @@ def binned_light_curve_plot(
 
         step_plot(
             time_bins[all_masks[0]],
-            old_div(cnts[all_masks[0]], width[all_masks[0]]),
+            cnts[all_masks[0]] / width[all_masks[0]],
             ax,
             color=selection_color,
             fill=True,
@@ -102,7 +101,7 @@ def binned_light_curve_plot(
             for mask in all_masks[1:]:
                 step_plot(
                     time_bins[mask],
-                    old_div(cnts[mask], width[mask]),
+                    cnts[mask] / width[mask],
                     ax,
                     color=background_selection_color,
                     fill=True,
@@ -112,7 +111,7 @@ def binned_light_curve_plot(
 
         step_plot(
             time_bins[all_masks[0]],
-            old_div(cnts[all_masks[0]], width[all_masks[0]]),
+            cnts[all_masks[0]] / width[all_masks[0]],
             ax,
             color=background_selection_color,
             fill=True,
@@ -142,7 +141,7 @@ def channel_plot(ax, chan_min, chan_max, counts, **kwargs):
     chans = np.vstack([chan_min, chan_max]).T
     width = chan_max - chan_min
 
-    step_plot(chans, old_div(counts, width), ax, **kwargs)
+    step_plot(chans, counts / width, ax, **kwargs)
     ax.set_xscale("log")
     ax.set_yscale("log")
 

--- a/threeML/io/rich_display.py
+++ b/threeML/io/rich_display.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 # This module handle the lazy dependence on IPython
 
 

--- a/threeML/io/serialization.py
+++ b/threeML/io/serialization.py
@@ -1,17 +1,9 @@
-from future import standard_library
-
 from threeML.bayesian.bayesian_analysis import BayesianAnalysis
 from threeML.classicMLE.joint_likelihood import JointLikelihood
 
-standard_library.install_aliases()
 __all__ = []
 
-# copyreg is called copy_reg in python2
-try:
-    import copyreg  # py3
-
-except ImportError:
-    import copyreg as copyreg  # py2
+import copyreg  # py3
 
 
 # Serialization for JointLikelihood object

--- a/threeML/io/uncertainty_formatter.py
+++ b/threeML/io/uncertainty_formatter.py
@@ -1,10 +1,7 @@
-from __future__ import division
-
 import re
 
 import numpy as np
 import uncertainties
-from past.utils import old_div
 
 from threeML.io.logging import setup_logger
 
@@ -112,9 +109,9 @@ def uncertainty_formatter(value, low_bound, hi_bound):
 
     order_of_magnitude = max(tmp)
 
-    scaled_value = old_div(value, order_of_magnitude)
-    scaled_error_m = old_div(error_m, order_of_magnitude)
-    scaled_error_p = old_div(error_p, order_of_magnitude)
+    scaled_value = value / order_of_magnitude
+    scaled_error_m = error_m / order_of_magnitude
+    scaled_error_p = error_p / order_of_magnitude
 
     # Get the uncertainties instance of the scaled values/errors
 

--- a/threeML/minimizer/minimization.py
+++ b/threeML/minimizer/minimization.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import collections
 import math
 from builtins import object, range, str, zip
@@ -7,7 +5,6 @@ from builtins import object, range, str, zip
 import numpy as np
 import pandas as pd
 import scipy.optimize
-from past.utils import old_div
 
 from threeML.config.config import threeML_config
 from threeML.exceptions.custom_exceptions import custom_warnings
@@ -473,9 +470,7 @@ class Minimizer(object):
                 else:
                     # Bounded only in the negative direction. Make sure we are not at
                     # the boundary
-                    if np.isclose(
-                        current_value, current_min, old_div(abs(current_value), 20)
-                    ):
+                    if np.isclose(current_value, current_min, abs(current_value) / 20):
                         log.warning(
                             "The current value of parameter %s is very close to "
                             "its lower bound when starting the fit. Fixing it"
@@ -496,9 +491,7 @@ class Minimizer(object):
                     # Bounded only in the positive direction
                     # Bounded only in the negative direction. Make sure we are not at
                     # the boundary
-                    if np.isclose(
-                        current_value, current_max, old_div(abs(current_value), 20)
-                    ):
+                    if np.isclose(current_value, current_max, abs(current_value) / 20):
                         log.warnings(
                             "The current value of parameter %s is very close to "
                             "its upper bound when starting the fit. Fixing it"
@@ -677,9 +670,9 @@ class Minimizer(object):
                     variance_j = self._covariance_matrix[j, j]
 
                     if variance_i * variance_j > 0:
-                        self._correlation_matrix[i, j] = old_div(
-                            self._covariance_matrix[i, j],
-                            (math.sqrt(variance_i * variance_j)),
+                        self._correlation_matrix[i, j] = float(
+                            self._covariance_matrix[i, j]
+                            / (math.sqrt(variance_i * variance_j)),
                         )
 
                     else:

--- a/threeML/minimizer/minuit_minimizer.py
+++ b/threeML/minimizer/minuit_minimizer.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import collections
 from builtins import range
 

--- a/threeML/minimizer/pagmo_minimizer.py
+++ b/threeML/minimizer/pagmo_minimizer.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 from builtins import object, range
 

--- a/threeML/minimizer/tutorial_material.py
+++ b/threeML/minimizer/tutorial_material.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from builtins import map, range, zip
 
 import matplotlib.pyplot as plt
@@ -13,7 +11,6 @@ from astromodels import (
     use_astromodels_memoization,
 )
 from matplotlib import colormaps
-from past.utils import old_div
 
 from threeML.classicMLE.joint_likelihood import JointLikelihood
 from threeML.data_list import DataList
@@ -288,7 +285,7 @@ class Complex(Simple):
 
         for i in range(3):
             self._gau += Gaussian(
-                F=100.0 / (i + 1), mu=10 + (i * 25), sigma=old_div(5, (i + 1))
+                F=100.0 / (i + 1), mu=10 + (i * 25), sigma=5 / (i + 1)
             )
 
         self._returned_values = []

--- a/threeML/plugins/FermiLATLike.py
+++ b/threeML/plugins/FermiLATLike.py
@@ -12,7 +12,6 @@ import UnbinnedAnalysis
 from astromodels import Model, Parameter
 from GtBurst import FuncFactory, LikelihoodComponent
 from matplotlib import gridspec
-from past.utils import old_div
 
 from threeML.config.config import threeML_config
 from threeML.config.plotting_structure import BinnedSpectrumPlot
@@ -644,8 +643,8 @@ class FermiLATLike(PluginPrototype):
 
         # Using model variance to account for low statistic
 
-        resid = old_div((self.like.nobs - sum_model), sum_model)
-        resid_err = old_div(numpy.sqrt(self.like.nobs), sum_model)
+        resid = (self.like.nobs - sum_model) / sum_model
+        resid_err = numpy.sqrt(self.like.nobs) / sum_model
 
         sub1.axhline(0, linestyle="--")
         sub1.errorbar(
@@ -865,8 +864,8 @@ class FermiLATLike(PluginPrototype):
         significance_calc = Significance(Non=y, Noff=sum_backgrounds)
 
         if False:
-            resid = old_div((self.like.nobs - sum_model), sum_model)
-            resid_err = old_div(y_err, sum_model)
+            resid = (self.like.nobs - sum_model) / sum_model
+            resid_err = y_err / sum_model
         else:
             # resid     = significance_calc.li_and_ma()
             resid = significance_calc.known_background()

--- a/threeML/plugins/FermipyLike.py
+++ b/threeML/plugins/FermipyLike.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import collections
 import os
 from typing import Any, Dict, List, Optional, Union
@@ -12,7 +10,6 @@ from astromodels import Parameter
 from astromodels.core import parameter_transformation
 from astropy import units as u
 from astropy.stats import circmean
-from past.utils import old_div
 
 from threeML.config.config import threeML_config as tc
 from threeML.config.plotting_structure import FermiSpectrumPlot
@@ -113,7 +110,7 @@ def _get_fermipy_instance(configuration, likelihood_model):
     dec_center = float(configuration["selection"]["dec"])
 
     roi_width = float(configuration["binning"]["roiwidth"])
-    roi_radius = old_div(roi_width, np.sqrt(2.0))
+    roi_radius = roi_width / np.sqrt(2.0)
 
     # Get IRFS
     irfs = evclass_irf[int(configuration["selection"]["evclass"])]
@@ -1197,8 +1194,8 @@ class FermipyLike(PluginPrototype):
         significance_calc = Significance(Non=y, Noff=sum_model)
 
         if ratio_residuals:
-            resid = old_div((y - sum_model), sum_model)
-            resid_err = old_div(y_err, sum_model)
+            resid = (y - sum_model) / sum_model
+            resid_err = y_err, sum_model
         else:
             # resid     = significance_calc.li_and_ma()
             resid = significance_calc.known_background()

--- a/threeML/plugins/HAWCLike.py
+++ b/threeML/plugins/HAWCLike.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function
-
 import collections
 import os
 from builtins import range, str
@@ -11,7 +9,6 @@ from astromodels import Parameter
 from cthreeML.pyModelInterfaceCache import pyToCppModelInterfaceCache
 from hawc import liff_3ML
 from matplotlib import gridspec
-from past.utils import old_div
 
 from threeML.exceptions.custom_exceptions import custom_warnings
 from threeML.io.file_utils import file_existing_and_readable, sanitize_filename
@@ -614,14 +611,14 @@ class HAWCLike(PluginPrototype):
 
         # Using model variance to account for low statistic
 
-        resid = old_div((signal - model), (error if pulls else model))
+        resid = (signal - model) / (error if pulls else model)
 
         sub1.axhline(0, linestyle="--")
 
         sub1.errorbar(
             bin_index,
             resid,
-            yerr=np.zeros(error.shape) if pulls else old_div(error, model),
+            yerr=np.zeros(error.shape) if pulls else error / model,
             capsize=0,
             fmt=".",
         )
@@ -704,7 +701,7 @@ class HAWCLike(PluginPrototype):
 
         list_of_bin_names = set(bin_list) & set(self._bin_list)
 
-        delta_r = old_div(1.0 * max_radius, n_radial_bins)
+        delta_r = 1.0 * max_radius / n_radial_bins
         radii = np.array([delta_r * (i + 0.5) for i in range(0, n_radial_bins)])
 
         # Use GetTopHatAreas to get the area of all pixels in a given circle.
@@ -782,7 +779,7 @@ class HAWCLike(PluginPrototype):
             self._theLikeHAWC.GetTopHatBackgrounds(ra, dec, max_radius)
         )[good_bins]
         w = np.divide(total_model, total_bkg)
-        weight = np.array([old_div(w, np.sum(w)) for r in radii])
+        weight = np.array([w / np.sum(w) for r in radii])
 
         # restrict profiles to the user-specified analysis bins.
         area = area[:, good_bins]
@@ -793,11 +790,9 @@ class HAWCLike(PluginPrototype):
 
         # average over the analysis bins
 
-        excess_data = np.average(old_div(signal, area), weights=weight, axis=1)
-        excess_error = np.sqrt(
-            np.sum(old_div(counts * weight * weight, (area * area)), axis=1)
-        )
-        excess_model = np.average(old_div(model, area), weights=weight, axis=1)
+        excess_data = np.average(signal / area, weights=weight, axis=1)
+        excess_error = np.sqrt(np.sum(counts * weight * weight / (area * area), axis=1))
+        excess_model = np.average(model / area, weights=weight, axis=1)
 
         return radii, excess_model, excess_data, excess_error, sorted(list_of_bin_names)
 

--- a/threeML/plugins/SpectrumLike.py
+++ b/threeML/plugins/SpectrumLike.py
@@ -12,7 +12,6 @@ import pandas as pd
 from astromodels import Model, PointSource, clone_model
 from astromodels.core.parameter import Parameter
 from astromodels.functions.priors import Truncated_gaussian, Uniform_prior
-from past.utils import old_div
 
 from threeML.config.config import threeML_config
 from threeML.config.plotting_structure import BinnedSpectrumPlot
@@ -3625,31 +3624,18 @@ class SpectrumLike(PluginPrototype):
 
         if source_only:
             y_label = "Net rate\n(counts s$^{-1}$ keV$^{-1}$)"
-            weighted_data = old_div(
+            weighted_data = (
                 rebinned_quantities["new_observed_rate"]
-                - rebinned_quantities["new_background_rate"],
-                rebinned_quantities["new_chan_width"],
-            )
-            weighted_error = old_div(
+                - rebinned_quantities["new_background_rate"]
+            ) / rebinned_quantities["new_chan_width"]
+            weighted_error = (
                 np.sqrt(
                     rebinned_quantities["new_observed_rate_err"] ** 2
                     + rebinned_quantities["new_background_rate_err"] ** 2
-                ),
-                rebinned_quantities["new_chan_width"],
+                )
+                / rebinned_quantities["new_chan_width"]
             )
-        else:
-            y_label = "Observed rate\n(counts s$^{-1}$ keV$^{-1}$)"
-            weighted_data = old_div(
-                rebinned_quantities["new_observed_rate"],
-                rebinned_quantities["new_chan_width"],
-            )
-            weighted_error = old_div(
-                rebinned_quantities["new_observed_rate_err"],
-                rebinned_quantities["new_chan_width"],
-            )
-        # weighted_data = old_div(
-        #    rebinned_quantities["new_rate"], rebinned_quantities["new_chan_width"]
-        # )
+
         # weighted_error = old_div(
         #    rebinned_quantities["new_err"], rebinned_quantities["new_chan_width"]
         # )
@@ -3712,10 +3698,8 @@ class SpectrumLike(PluginPrototype):
             # y = expected_model_rate / chan_width
             y = np.ma.masked_where(
                 ~self._mask,
-                old_div(
-                    rebinned_quantities["expected_model_rate"],
-                    rebinned_quantities["chan_width"],
-                ),
+                rebinned_quantities["expected_model_rate"]
+                / rebinned_quantities["chan_width"],
             )
 
             x = np.mean(

--- a/threeML/plugins/experimental/CastroLike.py
+++ b/threeML/plugins/experimental/CastroLike.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from builtins import object
 
 import matplotlib.pyplot as plt
@@ -7,7 +5,6 @@ import numpy as np
 import scipy.integrate
 import scipy.interpolate
 import scipy.optimize
-from past.utils import old_div
 
 from threeML.exceptions.custom_exceptions import custom_warnings
 from threeML.plugin_prototype import PluginPrototype
@@ -241,7 +238,7 @@ class CastroLike(PluginPrototype):
 
             length = interval_container.stop - interval_container.start
 
-            expected_flux = old_div(scipy.integrate.simps(yy, xx), length)
+            expected_flux = scipy.integrate.simps(yy, xx) / length
 
             this_log_l = interval_container(expected_flux)
 

--- a/threeML/plugins/experimental/SherpaLike.py
+++ b/threeML/plugins/experimental/SherpaLike.py
@@ -1,10 +1,7 @@
-from __future__ import division
-
 from builtins import object, range, zip
 
 import matplotlib.pyplot as plt
 import numpy as np
-from past.utils import old_div
 from sherpa.astro import datastack
 from sherpa.models import TableModel
 
@@ -205,9 +202,9 @@ class SherpaLike(PluginPrototype):
         axarr[0].legend()
         axarr[1].errorbar(
             energies[counts > 0],
-            (old_div((counts - tot), tot))[counts > 0],
+            ((counts - tot) / tot)[counts > 0],
             xerr=np.zeros(len(energies[counts > 0])),
-            yerr=(old_div(np.sqrt(counts), tot))[counts > 0],
+            yerr=(np.sqrt(counts) / tot)[counts > 0],
             fmt="ko",
             capsize=0,
         )

--- a/threeML/plugins/experimental/VERITASLike.py
+++ b/threeML/plugins/experimental/VERITASLike.py
@@ -1,12 +1,9 @@
-from __future__ import division, print_function
-
 import collections
 from builtins import object, range, zip
 
 import numpy as np
 import ROOT
 import scipy.integrate
-from past.utils import old_div
 
 from threeML.exceptions.custom_exceptions import custom_warnings
 from threeML.io.cern_root_utils.io_utils import get_list_of_keys, open_ROOT_file
@@ -190,11 +187,11 @@ class VERITASRun(object):
 
         # Added by for bin by bin normalization
         v_new = np.sum(self._hMigration, axis=1)
-        new_v = old_div(v_new, expectation)
+        new_v = v_new / expectation
         avg1_new = new_v
         avg2_new = np.interp(self._recon_energies_c, energies_eff, self._eff_area)
-        renorm_new = old_div(avg1_new, avg2_new)
-        hMigration_new = old_div(self._hMigration, renorm_new[:, None])
+        renorm_new = avg1_new / avg2_new
+        hMigration_new = self._hMigration / renorm_new[:, None]
         hMigration_new[~np.isfinite(hMigration_new)] = 0
 
         self._hMigration = hMigration_new
@@ -289,7 +286,7 @@ class VERITASRun(object):
     @staticmethod
     def _simulated_spectrum_f(e1, e2):
         def integral_f(x):
-            return old_div(-3.0, (x**0.5))
+            return -3.0 / (x**0.5)
 
         return integral_f(e2) - integral_f(e1)
 
@@ -317,20 +314,18 @@ class VERITASRun(object):
         dE = e2 - e1
 
         if not fast:
-            this_spectrum = old_div(
-                self._integrate(diff_flux, e1, e2), dE
-            )  # 1 / keV cm2 s
+            this_spectrum = self._integrate(diff_flux, e1, e2) / dE
+            # 1 / keV cm2 s
 
-            sim_spectrum = old_div(
-                self._simulated_spectrum_f(e1, e2), dE
-            )  # 1 / keV cm2 s
+            sim_spectrum = self._simulated_spectrum_f(e1, e2) / dE
+            # 1 / keV cm2 s
 
         else:
             this_spectrum = diff_flux(self._mc_energies_c)
 
             sim_spectrum = self._simulated_spectrum(self._mc_energies_c)
 
-        weight = old_div(this_spectrum, sim_spectrum)  # type: np.ndarray
+        weight = this_spectrum / sim_spectrum  # type: np.ndarray
 
         # print("Sum of weight: %s" % np.sum(weight))
 

--- a/threeML/test/test_AAA_against_xspec.py
+++ b/threeML/test/test_AAA_against_xspec.py
@@ -1,10 +1,7 @@
-from __future__ import division, print_function
-
 import os
 
 # NOTE: XSpec must be loaded before any other plugin/package from threeML because
 # otherwise it could complain about conflicting CFITSIO libraries
-from past.utils import old_div
 
 if os.environ.get("HEADAS") is not None:
     # Try to import xspec
@@ -87,7 +84,7 @@ def test_OGIP_response_against_xspec():
         powerlaw_integral.K._transformation = None
         powerlaw_integral.K.bounds = (None, None)
         powerlaw_integral.index = powerlaw.index.value + 1
-        powerlaw_integral.K = old_div(powerlaw.K.value, (powerlaw.index.value + 1))
+        powerlaw_integral.K = powerlaw.K.value / (powerlaw.index.value + 1)
 
         powerlaw_integral.display()
 
@@ -200,7 +197,7 @@ def test_response_against_xspec():
         powerlaw_integral.K._transformation = None
         powerlaw_integral.K.bounds = (None, None)
         powerlaw_integral.index = powerlaw.index.value + 1
-        powerlaw_integral.K = old_div(powerlaw.K.value, (powerlaw.index.value + 1))
+        powerlaw_integral.K = powerlaw.K.value / (powerlaw.index.value + 1)
 
         def integral_function(e1, e2):
             return powerlaw_integral(e2) - powerlaw_integral(e1)

--- a/threeML/test/test_analysis_results.py
+++ b/threeML/test/test_analysis_results.py
@@ -1,12 +1,9 @@
-from __future__ import division, print_function
-
 import os
 from builtins import zip
 
 import astropy.units as u
 import numpy as np
 from astromodels import Powerlaw
-from past.utils import old_div
 
 from threeML import (
     Model,
@@ -254,10 +251,10 @@ def test_error_propagation(xy_fitted_joint_likelihood):
 
     res = p1 + p2
 
-    assert old_div(abs(res.value - (p1.value + p2.value)), (p1.value + p2.value)) < 0.01
+    assert abs(res.value - (p1.value + p2.value)) / (p1.value + p2.value) < 0.01
 
     # Make ratio with error 0
-    res = old_div(p1, p1)
+    res = p1 / p1
 
     low_b, hi_b = res.equal_tail_interval()
 

--- a/threeML/test/test_event_list.py
+++ b/threeML/test/test_event_list.py
@@ -1,10 +1,7 @@
-from __future__ import division
-
 import os
 
 import numpy as np
 import pytest
-from past.utils import old_div
 
 from threeML.utils.time_interval import TimeIntervalSet
 from threeML.utils.time_series.event_list import EventList, EventListWithDeadTime
@@ -18,7 +15,7 @@ datasets_dir = get_test_datasets_directory()
 def is_within_tolerance(truth, value, relative_tolerance=0.01):
     assert truth != 0
 
-    if abs(old_div((truth - value), truth)) <= relative_tolerance:
+    if abs((truth - value) / truth) <= relative_tolerance:
         return True
 
     else:

--- a/threeML/test/test_hawc.py
+++ b/threeML/test/test_hawc.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function
-
 import os
 
 import astropy.units as u
@@ -12,7 +10,6 @@ from astromodels import (
     Model,
     PointSource,
 )
-from past.utils import old_div
 
 from threeML import DataList, JointLikelihood, is_plugin_available
 
@@ -38,7 +35,7 @@ skip_if_hawc_is_not_available = pytest.mark.skipif(
 def is_within_tolerance(truth, value, relative_tolerance=0.01):
     assert truth != 0
 
-    if abs(old_div((truth - value), truth)) <= relative_tolerance:
+    if abs((truth - value) / truth) <= relative_tolerance:
         return True
 
     else:
@@ -78,7 +75,7 @@ def hawc_point_source_fitted_joint_like():
     spectrum = Cutoff_powerlaw()
     source = PointSource("TestSource", ra=100.0, dec=22.0, spectral_shape=spectrum)
 
-    spectrum.K = old_div(3.15e-11, (u.TeV * u.cm**2 * u.s))
+    spectrum.K = 3.15e-11 / (u.TeV * u.cm**2 * u.s)
     spectrum.K.bounds = (1e-22, 1e-18)  # without units energies are in keV
 
     spectrum.piv = 1 * u.TeV
@@ -161,7 +158,7 @@ def test_hawc_fullsky_options():
     spectrum = Cutoff_powerlaw()
     source = PointSource("TestSource", ra=100.0, dec=22.0, spectral_shape=spectrum)
 
-    spectrum.K = old_div(3.15e-11, (u.TeV * u.cm**2 * u.s))
+    spectrum.K = 3.15e-11 / (u.TeV * u.cm**2 * u.s)
     spectrum.K.bounds = (1e-22, 1e-18)  # without units energies are in keV
 
     spectrum.piv = 1 * u.TeV
@@ -261,7 +258,7 @@ def test_hawc_point_source_fit(hawc_point_source_fitted_joint_like):
     # Get the differential flux at 1 TeV
     diff_flux = spectrum(1 * u.TeV)
     # Convert it to 1 / (TeV cm2 s)
-    diff_flux_TeV = diff_flux.to(old_div(1, (u.TeV * u.cm**2 * u.s)))
+    diff_flux_TeV = diff_flux.to(1 / (u.TeV * u.cm**2 * u.s))
 
     print("Norm @ 1 TeV:  %s \n" % diff_flux_TeV)
 
@@ -375,7 +372,7 @@ def test_hawc_extended_source_fit():
     # Get the differential flux at 1 TeV
     diff_flux = spectrum(1 * u.TeV)
     # Convert it to 1 / (TeV cm2 s)
-    diff_flux_TeV = diff_flux.to(old_div(1, (u.TeV * u.cm**2 * u.s)))
+    diff_flux_TeV = diff_flux.to(1 / (u.TeV * u.cm**2 * u.s))
 
     print("Norm @ 1 TeV:  %s \n" % diff_flux_TeV)
 
@@ -567,7 +564,7 @@ def test_CommonNorm_fit():
     spectrum = Cutoff_powerlaw()
     source = PointSource("TestSource", ra=100.0, dec=22.0, spectral_shape=spectrum)
 
-    spectrum.K = old_div(3.15e-11, (u.TeV * u.cm**2 * u.s))
+    spectrum.K = 3.15e-11 / (u.TeV * u.cm**2 * u.s)
     spectrum.K.bounds = (1e-22, 1e-18)  # without units energies are in keV
     spectrum.K.fix = True
 

--- a/threeML/test/test_histogram.py
+++ b/threeML/test/test_histogram.py
@@ -1,10 +1,7 @@
-from __future__ import division
-
 import os
 
 import numpy as np
 import pytest
-from past.utils import old_div
 
 from threeML.io.file_utils import within_directory
 from threeML.utils.histogram import Histogram
@@ -16,7 +13,7 @@ __this_dir__ = os.path.join(os.path.abspath(os.path.dirname(__file__)))
 def is_within_tolerance(truth, value, relative_tolerance=0.01):
     assert truth != 0
 
-    if abs(old_div((truth - value), truth)) <= relative_tolerance:
+    if abs((truth - value) / truth) <= relative_tolerance:
         return True
 
     else:

--- a/threeML/test/test_joint_likelihood_set.py
+++ b/threeML/test/test_joint_likelihood_set.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import pytest
 from astromodels import Powerlaw
 

--- a/threeML/test/test_spectrum_class.py
+++ b/threeML/test/test_spectrum_class.py
@@ -1,11 +1,8 @@
-from __future__ import division
-
 import os
 
 import numpy as np
 import pytest
 from astromodels import Model, PointSource, Powerlaw
-from past.utils import old_div
 
 from threeML.plugins.DispersionSpectrumLike import DispersionSpectrumLike
 from threeML.plugins.SpectrumLike import SpectrumLike
@@ -117,6 +114,14 @@ def addition_proof_simple(x, y, z):
 
 
 def addition_proof_weighted(x, y, z):
+    assert (
+        (x.rates[3] / x.rate_errors[3] ** 2) + (y.rates[3] / y.rate_errors[3] ** 2)
+    ) / ((1 / x.rate_errors[3] ** 2) + (1 / y.rate_errors[3] ** 2)) == (
+        z.rates[3] / z.exposure
+    )
+
+
+"""
     assert old_div(
         (
             old_div(x.rates[3], x.rate_errors[3] ** 2)
@@ -124,6 +129,7 @@ def addition_proof_weighted(x, y, z):
         ),
         (old_div(1, x.rate_errors[3] ** 2) + old_div(1, y.rate_errors[3] ** 2)),
     ) == old_div(z.rates[3], z.exposure)
+"""
 
 
 def spectrum_addition(

--- a/threeML/test/test_time_interval.py
+++ b/threeML/test/test_time_interval.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from builtins import zip
 
 import pytest

--- a/threeML/utils/OGIP/response.py
+++ b/threeML/utils/OGIP/response.py
@@ -10,7 +10,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import colormaps
 from matplotlib.colors import SymLogNorm
-from past.utils import old_div
 
 from threeML.config import threeML_config
 from threeML.exceptions.custom_exceptions import custom_warnings
@@ -690,9 +689,9 @@ class OGIPResponse(InstrumentResponse):
 
         idx = self.monte_carlo_energies > 0
 
-        diff = old_div(
-            (self.monte_carlo_energies[idx] - arf_mc_channels[idx]),
-            self.monte_carlo_energies[idx],
+        diff = np.array(
+            (self.monte_carlo_energies[idx] - arf_mc_channels[idx])
+            / self.monte_carlo_energies[idx],
         )
 
         if diff.max() > 0.01:

--- a/threeML/utils/data_download/Fermi_GBM/download_GBM_data.py
+++ b/threeML/utils/data_download/Fermi_GBM/download_GBM_data.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import re
 from builtins import map

--- a/threeML/utils/data_download/Fermi_LAT/download_LAT_data.py
+++ b/threeML/utils/data_download/Fermi_LAT/download_LAT_data.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import html.parser
 import os
 import re

--- a/threeML/utils/data_download/Fermi_LAT/download_LLE_data.py
+++ b/threeML/utils/data_download/Fermi_LAT/download_LLE_data.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import re
 from collections import OrderedDict

--- a/threeML/utils/fitted_objects/fitted_point_sources.py
+++ b/threeML/utils/fitted_objects/fitted_point_sources.py
@@ -1,7 +1,3 @@
-from __future__ import division
-
-from past.utils import old_div
-
 __author__ = "grburgess"
 
 import collections
@@ -128,8 +124,8 @@ class DifferentialFluxConversion(FluxConversion):
 
         self._flux_lookup = {
             "photon_flux": 1.0 / (u.keV * u.cm**2 * u.s),
-            "energy_flux": old_div(u.erg, (u.keV * u.cm**2 * u.s)),
-            "nufnu_flux": old_div(u.erg**2, (u.keV * u.cm**2 * u.s)),
+            "energy_flux": u.erg / (u.keV * u.cm**2 * u.s),
+            "nufnu_flux": u.erg**2 / (u.keV * u.cm**2 * u.s),
         }
 
         self._model_converter = {
@@ -176,8 +172,8 @@ class IntegralFluxConversion(FluxConversion):
 
         self._flux_lookup = {
             "photon_flux": 1.0 / (u.cm**2 * u.s),
-            "energy_flux": old_div(u.erg, (u.cm**2 * u.s)),
-            "nufnu_flux": old_div(u.erg**2, (u.cm**2 * u.s)),
+            "energy_flux": u.erg / (u.cm**2 * u.s),
+            "nufnu_flux": u.erg**2 / (u.cm**2 * u.s),
         }
 
         self._model_converter = {

--- a/threeML/utils/photometry/filter_set.py
+++ b/threeML/utils/photometry/filter_set.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from builtins import object, zip
 
 import astropy.constants as constants

--- a/threeML/utils/spectrum/pha_spectrum.py
+++ b/threeML/utils/spectrum/pha_spectrum.py
@@ -4,8 +4,6 @@ from typing import Any, Dict, Iterable, Optional, Union
 
 import astropy.io.fits as fits
 import numpy as np
-import six
-from past.utils import old_div
 
 from threeML.io.fits_file import FITSFile
 from threeML.io.logging import setup_logger
@@ -416,7 +414,7 @@ def _read_pha_or_pha2_file(
                 # Read in the response
 
         if (
-            isinstance(rsp_file, six.string_types)
+            isinstance(rsp_file, str)
             or isinstance(rsp_file, str)
             or isinstance(rsp_file, Path)
         ):
@@ -482,8 +480,8 @@ def _read_pha_or_pha2_file(
                 rate_errors = None
 
                 if not is_poisson:
-                    rate_errors = old_div(
-                        data.field("STAT_ERR")[spectrum_number - 1, :], exposure
+                    rate_errors = (
+                        data.field("STAT_ERR")[spectrum_number - 1, :] / exposure
                     )
 
             else:
@@ -494,9 +492,7 @@ def _read_pha_or_pha2_file(
                 rate_errors = None
 
                 if not is_poisson:
-                    rate_errors = old_div(
-                        data.field("STAT_ERR"), np.atleast_2d(exposure).T
-                    )
+                    rate_errors = data.field("STAT_ERR") / np.atleast_2d(exposure).T
 
         if "SYS_ERR" in data.columns.names:
             if not treat_as_time_series:
@@ -605,7 +601,7 @@ def _read_pha_or_pha2_file(
             rate_errors = None
 
             if not is_poisson:
-                rate_errors = old_div(data.field("STAT_ERR"), exposure)
+                rate_errors = data.field("STAT_ERR") / exposure
 
         if "SYS_ERR" in data.columns.names:
             sys_errors = data.field("SYS_ERR")
@@ -893,7 +889,7 @@ class PHASpectrum(BinnedSpectrumWithDispersion):
             stat_err = None
 
         else:
-            stat_err = old_div(new_count_errors, new_exposure)
+            stat_err = new_count_errors / new_exposure
 
         if self._tstart is None:
             tstart = 0
@@ -918,7 +914,7 @@ class PHASpectrum(BinnedSpectrumWithDispersion):
             tstart=tstart,
             telapse=telapse,
             channel=list(range(1, len(self) + 1)),
-            rate=old_div(new_counts, self.exposure),
+            rate=new_counts / self.exposure,
             stat_err=stat_err,
             quality=self.quality.to_ogip(),
             grouping=self.grouping,
@@ -1243,7 +1239,7 @@ class PHASpectrumSet(BinnedSpectrumSet):
             stat_err = None
 
         else:
-            stat_err = old_div(new_count_errors, self.exposure)
+            stat_err = new_count_errors / self.exposure
 
         # create a new PHAII instance
 
@@ -1253,7 +1249,7 @@ class PHASpectrumSet(BinnedSpectrumSet):
             tstart=0,
             telapse=self.exposure,
             channel=list(range(1, len(self) + 1)),
-            rate=old_div(new_counts, self.exposure),
+            rate=new_counts / self.exposure,
             stat_err=stat_err,
             quality=self.quality.to_ogip(),
             grouping=self.grouping,

--- a/threeML/utils/time_series/binned_spectrum_series.py
+++ b/threeML/utils/time_series/binned_spectrum_series.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function
-
 from builtins import range, zip
 
 import matplotlib.pyplot as plt

--- a/threeML/utils/time_series/event_list.py
+++ b/threeML/utils/time_series/event_list.py
@@ -1,8 +1,4 @@
-from __future__ import division, print_function
-
 from builtins import range, zip
-
-from past.utils import old_div
 
 __author__ = "grburgess"
 
@@ -347,7 +343,7 @@ class EventList(TimeSeries):
                 # We do not use the dead time corrected exposure here
                 # because the integration is done over the full time bin
                 # and not the dead time corrected exposure
-                bkg.append(old_div(tmpbkg, tb[1] - tb[0]))
+                bkg.append(tmpbkg / (tb[1] - tb[0]))
 
         else:
             bkg = None
@@ -1093,7 +1089,7 @@ class EventListWithLiveTime(EventList):
 
             dt = self._live_time_stops[inside_idx] - self._live_time_starts[inside_idx]
 
-            fraction = old_div((stop - start), dt)
+            fraction = (stop - start) / dt
 
             total_livetime = self._live_time[inside_idx] * fraction
 
@@ -1126,7 +1122,7 @@ class EventListWithLiveTime(EventList):
 
             distance_from_next_bin = self._live_time_stops[left_remainder_idx] - start
 
-            fraction = old_div(distance_from_next_bin, dt)
+            fraction = distance_from_next_bin / dt
 
             left_fractional_livetime = self._live_time[left_remainder_idx] * fraction
 
@@ -1145,7 +1141,7 @@ class EventListWithLiveTime(EventList):
 
             distance_from_next_bin = stop - self._live_time_starts[right_remainder_idx]
 
-            fraction = old_div(distance_from_next_bin, dt)
+            fraction = distance_from_next_bin / dt
 
             right_fractional_livetime = self._live_time[right_remainder_idx] * fraction
 


### PR DESCRIPTION
Same as [astromodels PR 227](https://github.com/threeML/astromodels/pull/227) --> remove `past`, `future` and `six` functions used for python 2 compatibility