### PR TITLE
Using weakref instead of strong callback links.

### DIFF
--- a/threeML/bayesian/emcee_sampler.py
+++ b/threeML/bayesian/emcee_sampler.py
@@ -98,12 +98,12 @@ class EmceeSampler(MCMCSampler):
                 view = c[:]
 
                 sampler = emcee.EnsembleSampler(
-                    self._n_walkers, n_dim, self.get_posterior, pool=view
+                    self._n_walkers, n_dim, self.get_posterior_proxy(), pool=view
                 )
 
             else:
                 sampler = emcee.EnsembleSampler(
-                    self._n_walkers, n_dim, self.get_posterior
+                    self._n_walkers, n_dim, self.get_posterior_proxy()
                 )
 
             # If a seed is provided, set the random number seed

--- a/threeML/bayesian/sampler_base.py
+++ b/threeML/bayesian/sampler_base.py
@@ -1,6 +1,7 @@
 import abc
 import collections
 import math
+import weakref
 from typing import Dict, Optional
 
 import numpy as np
@@ -316,6 +317,26 @@ class SamplerBase(metaclass=abc.ABCMeta):
 
         return log_like + log_prior
 
+    def get_posterior_proxy(self):
+        """
+        Return a weakref-backed posterior callable.
+
+        This prevents external samplers from keeping a strong reference to this
+        SamplerBase instance via a bound method.
+        """
+
+        sampler_ref = weakref.ref(self)
+
+        def posterior(trial_values):
+            sampler = sampler_ref()
+
+            if sampler is None:
+                return -np.inf
+
+            return sampler.get_posterior(trial_values)
+
+        return posterior
+
     def _log_prior(self, trial_values) -> float:
         """Compute the sum of log-priors, used in the parallel tempering
         sampling."""
@@ -458,14 +479,21 @@ class UnitCubeSampler(SamplerBase):
         # construction of the class)
         self._update_free_parameters()
 
+        sampler_ref = weakref.ref(self)
+
         def loglike(trial_values, ndim=None, params=None):
+            sampler = sampler_ref()
+
+            if sampler is None:
+                return -np.inf
+
             # NOTE: the _log_like function DOES NOT assign trial_values to the
             # parameters
 
-            for i, parameter in enumerate(self._free_parameters.values()):
+            for i, parameter in enumerate(sampler._free_parameters.values()):
                 parameter.value = trial_values[i]
 
-            log_like = self._log_like(trial_values)
+            log_like = sampler._log_like(trial_values)
 
             return log_like
 
@@ -477,10 +505,15 @@ class UnitCubeSampler(SamplerBase):
         if return_copy:
 
             def prior(cube):
+                sampler = sampler_ref()
+
+                if sampler is None:
+                    return cube.copy()
+
                 params = cube.copy()
 
                 for i, (parameter_name, parameter) in enumerate(
-                    self._free_parameters.items()
+                    sampler._free_parameters.items()
                 ):
                     try:
                         params[i] = parameter.prior.from_unit_cube(params[i])
@@ -496,8 +529,13 @@ class UnitCubeSampler(SamplerBase):
         else:
 
             def prior(params, ndim=None, nparams=None):
+                sampler = sampler_ref()
+
+                if sampler is None:
+                    return
+
                 for i, (parameter_name, parameter) in enumerate(
-                    self._free_parameters.items()
+                    sampler._free_parameters.items()
                 ):
                     try:
                         params[i] = parameter.prior.from_unit_cube(params[i])

--- a/threeML/bayesian/zeus_sampler.py
+++ b/threeML/bayesian/zeus_sampler.py
@@ -96,7 +96,7 @@ class ZeusSampler(MCMCSampler):
             if using_mpi:
                 with MPIPoolExecutor() as executor:
                     sampler = zeus.EnsembleSampler(
-                        logprob_fn=self.get_posterior,
+                        logprob_fn=self.get_posterior_proxy(),
                         nwalkers=self._n_walkers,
                         ndim=n_dim,
                         pool=executor,
@@ -120,7 +120,7 @@ class ZeusSampler(MCMCSampler):
                 view = c[:]
 
                 sampler = zeus.EnsembleSampler(
-                    logprob_fn=self.get_posterior,
+                    logprob_fn=self.get_posterior_proxy(),
                     nwalkers=self._n_walkers,
                     ndim=n_dim,
                     pool=view,
@@ -128,7 +128,9 @@ class ZeusSampler(MCMCSampler):
 
             else:
                 sampler = zeus.EnsembleSampler(
-                    logprob_fn=self.get_posterior, nwalkers=self._n_walkers, ndim=n_dim
+                    logprob_fn=self.get_posterior_proxy(),
+                    nwalkers=self._n_walkers,
+                    ndim=n_dim,
                 )
 
             # If a seed is provided, set the random number seed

--- a/threeML/classicMLE/joint_likelihood.py
+++ b/threeML/classicMLE/joint_likelihood.py
@@ -1,5 +1,6 @@
 import collections
 import sys
+import weakref
 from builtins import object, range, zip
 
 import matplotlib.pyplot as plt
@@ -45,6 +46,28 @@ class ReducingNumberOfSteps(Warning):
 
 class NotANumberInLikelihood(Warning):
     pass
+
+
+class _WeakMinusLogLikeProxy(object):
+    """
+    Callable proxy that avoids strong references to JointLikelihood.
+
+    Some minimizers (notably iminuit) can keep the objective callable alive
+    longer than expected. If the callable is a bound method, that can retain
+    the entire JointLikelihood/DataList/plugin graph. Using a weakref-backed
+    proxy breaks that retention chain.
+    """
+
+    def __init__(self, jl):
+        self._jl_ref = weakref.ref(jl)
+
+    def __call__(self, *trial_values):
+        jl = self._jl_ref()
+
+        if jl is None:
+            return minimization.FIT_FAILED
+
+        return jl.minus_log_like_profile(*trial_values)
 
 
 class JointLikelihood(object):
@@ -116,6 +139,7 @@ class JointLikelihood(object):
         self._minimizer_callback = None
 
         self._analysis_results = None
+        self._minus_log_like_proxy = _WeakMinusLogLikeProxy(self)
 
     def _assign_model_to_data(self, model) -> None:
         log.debug("REGISTERING MODEL")
@@ -265,7 +289,7 @@ class JointLikelihood(object):
                     verbosity = 1
 
                 global_minimizer = self._get_minimizer(
-                    self.minus_log_like_profile,
+                    self._minus_log_like_proxy,
                     self._free_parameters,
                     verbosity=verbosity,
                 )
@@ -303,7 +327,7 @@ class JointLikelihood(object):
 
                 # Now set up secondary minimizer
                 self._minimizer = self._minimizer_type.get_second_minimization_instance(
-                    self.minus_log_like_profile, self._free_parameters
+                    self._minus_log_like_proxy, self._free_parameters
                 )
 
             else:
@@ -312,7 +336,7 @@ class JointLikelihood(object):
                 log.debug("starting local optimization")
 
                 self._minimizer = self._get_minimizer(
-                    self.minus_log_like_profile, self._free_parameters
+                    self._minus_log_like_proxy, self._free_parameters
                 )
 
             # Perform the fit, but first flush stdout (so if we have verbose=True the
@@ -526,7 +550,6 @@ class JointLikelihood(object):
             raise NoFitYet()
 
         # Then restore the best fit
-
         self._minimizer.restore_best_fit()
 
         # Check minimal assumptions about the procedure
@@ -679,7 +702,7 @@ class JointLikelihood(object):
                 ]
 
                 this_minimizer = self._get_minimizer(
-                    self.minus_log_like_profile, self._free_parameters
+                    self._minus_log_like_proxy, self._free_parameters
                 )
 
                 this_p1min = pa[start_index * p1_split_steps]

--- a/threeML/test/test_gc_issue.py
+++ b/threeML/test/test_gc_issue.py
@@ -1,0 +1,156 @@
+import gc
+import os
+import weakref
+
+import numpy as np
+import pytest
+from astromodels import (
+    Disk_on_sphere,
+    ExtendedSource,
+    Gaussian,
+    Model,
+    Uniform_prior,
+)
+
+from threeML import BayesianAnalysis, DataList, JointLikelihood, PluginPrototype
+
+
+class MemoryHeavyPlugin(PluginPrototype):
+    def __init__(self, name, mb=32):
+        super().__init__(name, {})
+        # Large array used to detect retention/leaks across iterations.
+        n_float64 = mb * 1024 * 1024 // 8
+        self.bigarray = np.ones(n_float64, dtype=np.float64)
+
+    def set_model(self, model):
+        self._model = model
+
+    def get_log_like(self):
+        f_value = (
+            list(self._model.extended_sources.values())[0].spectrum.main.shape.F.value
+        )
+        return -(f_value - 10.0) ** 2
+
+    def inner_fit(self):
+        return self.get_log_like()
+
+
+def _make_model(for_bayesian=False):
+    src = ExtendedSource(
+        "src",
+        spectral_shape=Gaussian(),
+        spatial_shape=Disk_on_sphere(),
+    )
+
+    src.spectrum.main.shape.F.value = 3e-5
+    src.spectrum.main.shape.F.min_value = 0
+    src.spectrum.main.shape.F.max_value = 100
+    src.spectrum.main.shape.F.free = True
+
+    if for_bayesian:
+        src.spectrum.main.shape.F.prior = Uniform_prior(lower_bound=0, upper_bound=100)
+
+    src.spectrum.main.shape.mu.free = False
+    src.spectrum.main.shape.sigma.free = False
+    src.spatial_shape.lon0.free = False
+    src.spatial_shape.lat0.free = False
+    src.spatial_shape.radius.free = False
+
+    return Model(src)
+
+
+def _rss_mb():
+    psutil = pytest.importorskip("psutil")
+    process = psutil.Process(os.getpid())
+    return process.memory_info().rss / 1024**2
+
+
+def test_joint_likelihood_plugins_are_collected():
+    model = _make_model(for_bayesian=False)
+
+    for i in range(6):
+        plugin = MemoryHeavyPlugin(f"mle_{i}")
+        plugin_ref = weakref.ref(plugin)
+
+        data = DataList(plugin)
+        like = JointLikelihood(model, data, verbose=False, record=False)
+        like.fit(quiet=True, compute_covariance=False)
+
+        del like
+        del data
+        del plugin
+        gc.collect()
+
+        assert plugin_ref() is None
+
+
+def test_bayesian_plugins_are_collected():
+    pytest.importorskip("emcee")
+
+    model = _make_model(for_bayesian=True)
+
+    for i in range(4):
+        plugin = MemoryHeavyPlugin(f"bayes_{i}")
+        plugin_ref = weakref.ref(plugin)
+
+        data = DataList(plugin)
+        bayes = BayesianAnalysis(model, data)
+        bayes.set_sampler("emcee")
+        bayes.sampler.setup(n_iterations=8, n_burn_in=8, n_walkers=10, seed=1234)
+        bayes.sample(quiet=True)
+
+        del bayes
+        del data
+        del plugin
+        gc.collect()
+
+        assert plugin_ref() is None
+
+
+def test_joint_likelihood_rss_does_not_grow_linearly():
+    model = _make_model(for_bayesian=False)
+    baseline = []
+    chunk_mb = 32
+
+    for i in range(6):
+        gc.collect()
+        baseline.append(_rss_mb())
+
+        plugin = MemoryHeavyPlugin(f"mle_rss_{i}", mb=chunk_mb)
+        data = DataList(plugin)
+        like = JointLikelihood(model, data, verbose=False, record=False)
+        like.fit(quiet=True, compute_covariance=False)
+
+        del like
+        del data
+        del plugin
+
+    drift_mb = baseline[-1] - baseline[0]
+    # Leaking would be ~N*chunk_mb. Allow broad allocator noise.
+    assert drift_mb < 3.0 * chunk_mb
+
+
+def test_bayesian_rss_does_not_grow_linearly():
+    pytest.importorskip("emcee")
+
+    model = _make_model(for_bayesian=True)
+    baseline = []
+    chunk_mb = 32
+
+    for i in range(4):
+        gc.collect()
+        baseline.append(_rss_mb())
+
+        plugin = MemoryHeavyPlugin(f"bayes_rss_{i}", mb=chunk_mb)
+        data = DataList(plugin)
+        bayes = BayesianAnalysis(model, data)
+        bayes.set_sampler("emcee")
+        bayes.sampler.setup(n_iterations=8, n_burn_in=8, n_walkers=10, seed=1234)
+        bayes.sample(quiet=True)
+
+        del bayes
+        del data
+        del plugin
+
+    drift_mb = baseline[-1] - baseline[0]
+    assert drift_mb < 3.0 * chunk_mb


### PR DESCRIPTION
Implemented a reference-retention fix for issue #663 by removing strong callback links from optimization/sampling backends to analysis objects.

### Root cause
* The objective/posterior callbacks were passed as bound methods (self.method).
* Backends (notably iminuit, and similarly MCMC samplers) keep those callables, which can retain the full analysis object graph (JointLikelihood / SamplerBase -> DataList -> plugins), preventing timely garbage collection.

### Fix and changes
* Added a weakref-backed callable proxy in ``threeML/classicMLE/joint_likelihood.py``: ``_WeakMinusLogLikeProxy``
* Replaced all minimizer callback wiring to use that proxy instead of bound methods.
* Added weakref-backed posterior callable in ``threeML/bayesian/sampler_base.py``: ``get_posterior_proxy()``
* Updated unit-cube posterior builder (``_construct_unitcube_posterior``) so loglike and prior closures use weakrefs instead of strongly capturing self.
Updated samplers that explicitly used bound methods: ``emcee`` and ``zeus``.
* Added a test ``threeML/test/test_gc_issue.py``

<!-- readthedocs-preview threeml start -->
----
📚 Documentation preview 📚: https://threeml--664.org.readthedocs.build/en/664/

<!-- readthedocs-preview threeml end -->