### PR TITLE
Use logging.getLogger(__name__) instead of setup_logger.

### DIFF
--- a/docs/md_docs/fast_execute/configuration.md
+++ b/docs/md_docs/fast_execute/configuration.md
@@ -66,7 +66,6 @@ plugins:
 ```yaml
 logging:
   developer: on
-  startup_warnings: off
 ```
 
 ```python
@@ -84,7 +83,6 @@ logging:
   path: ${env:USER_LOG_DIR}
   developer: off
   console: off
-  startup_warnings: off
 ```
 
 where ```USER_LOG_DIR``` could be a directory where you are allowed to write to disk. At run time, we convert this variable to a path. However, any value can be set. Thus, you can make an adaptable configuration that mutates based on your local workstation. 

--- a/docs/md_docs/fast_execute/logging.md
+++ b/docs/md_docs/fast_execute/logging.md
@@ -16,7 +16,40 @@ jupyter:
 <!-- #region -->
 # Logging and Verbosity
 
-We have recently switched to reporting information to the user via logging. Logging in 3ML occurs in three different ways:
+We use the [`logging`](https://docs.python.org/3/library/logging.html) library to manage all logs. 
+The `logging` needs to be configured by the application using 3ML --e.g. a script, an interactive notebook, etc-- 
+for example:
+
+```python
+# myapp.py
+import logging
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+```
+
+See the `logging` library documentation for further details.
+
+For convenience, 3ML provides a custom logging configuration, which
+can be activated with:
+
+```python
+# myapp.py
+import logging
+from threeML.io.logging import setup_logger
+logger = setup_logger(__name__)
+```
+
+The logging behavior can be further configured with the instructions
+below. Note that these 3ML-specific logging configuration only 
+take effect if your logger was instantiated using 3ML's `setup_logger`.
+
+NOTE: Until recently, 3ML configured its own logger by default. 
+Now you need to call `setup_logger` if you want to recover the
+previous behavior.
+
+## Logging handlers
+
+Logging in 3ML occurs in three different ways:
 
 * to the console (jupyter or command line)
 * a user log file
@@ -24,22 +57,11 @@ We have recently switched to reporting information to the user via logging. Logg
 
 The first two files record information relvant to the average 3ML user. The debug file records low level information useful when trying to solve runtime errors. 
 
+## Configuration
 
 The logging of 3ML is configurable in the configuration file.
 
-<!-- #endregion -->
-
-
-```python 
-import warnings
-warnings.simplefilter('ignore')
-import numpy as np
-np.seterr(all="ignore")
-```
-
-
 ```python
-%%capture
 from threeML import threeML_config
 
 threeML_config["logging"]
@@ -47,6 +69,25 @@ threeML_config["logging"]
 
 First, **the location of the log files can be set** before start a 3ML session in python. By default, logging to the debug file is off (**developer** switch). The **console** and **usr** switches can also be disabled by default to completely silence 3ML. Additionally, the default logging level of 3ML can be set for both the usr and console logs.
 
+## Startup warnings
+
+3ML checks the availability of various plugins and external libraries
+during the library initialization. While these warnings are usual benign,
+if it is important for your application to record these warning 
+you can log them at any point by calling
+
+```python
+from threeML.io.logging import log_threeml_startup_warnings
+from astromodels.utils.logging import log_astromodels_startup_warnings
+log_astromodels_startup_warnings(logger)
+log_threeml_startup_warnings(logger)
+```
+
+Here, `logger` can be an arbitrary `Logger`, whether it was configured by
+3ML or not.
+
+NOTE: until recently, these warnings were logged and printed by default.
+Now you need to call the function above explicitely.
 
 ## Logging controls and verbosity
 

--- a/threeML/__init__.py
+++ b/threeML/__init__.py
@@ -8,6 +8,8 @@ import warnings
 
 import pandas as pd
 
+from .io.logging import add_startup_warning
+
 pd.set_option("display.max_columns", None)
 
 
@@ -39,19 +41,8 @@ from .config import (
 
 log = logging.getLogger(__name__)
 
-if threeML_config["logging"]["startup_warnings"]:
-    log.info("Starting 3ML!")
-    log.warning("WARNINGs here are [red]NOT[/red] errors")
-    log.warning("but are inform you about optional packages that can be installed")
-    log.warning(
-        "[red] to disable these messages, turn off start_warning in your config file[/red]"
-    )
-
 if os.environ.get("DISPLAY") is None:
-    if threeML_config["logging"]["startup_warnings"]:
-        log.warning(
-            "no display variable set. using backend for graphics without display (agg)"
-        )
+    add_startup_warning(log, "no display variable set. using backend for graphics without display (agg)")
 
     import matplotlib as mpl
 
@@ -121,12 +112,8 @@ for i, module_full_path in enumerate(found_plugins):
     is_importable, result = is_module_importable(module_full_path)
 
     if not is_importable:
-        if threeML_config.logging.startup_warnings:
-            log.warning(
-                f"Could not import plugin {module_full_path.name}. Do you have the relative instrument software installed "
-                "and configured?"
-                # custom_exceptions.CannotImportPlugin,
-            )
+        add_startup_warning(log, f"Could not import plugin {module_full_path.name}. Do you have the relative instrument software installed "
+                "and configured?")
 
         _not_working_plugins[plugin_name] = result
 
@@ -165,13 +152,11 @@ def get_available_plugins():
 
 
 def _display_plugin_traceback(plugin):
-    if threeML_config.logging.startup_warnings:
-        log.warning("#############################################################")
-        log.warning("\nCouldn't import plugin %s" % plugin)
-        log.warning("\nTraceback:\n")
-        log.warning(_not_working_plugins[plugin])
-        log.warning("#############################################################")
-
+    add_startup_warning("#############################################################")
+    add_startup_warning("\nCouldn't import plugin %s" % plugin)
+    add_startup_warning("\nTraceback:\n")
+    add_startup_warning(_not_working_plugins[plugin])
+    add_startup_warning("#############################################################")
 
 def is_plugin_available(plugin):
     """Test whether the plugin for the provided instrument is available.
@@ -322,21 +307,14 @@ for var in var_to_check:
             num_threads = int(num_threads)
 
         except ValueError:
-            if threeML_config.logging.startup_warnings:
-                log.warning(
-                    "Your env. variable %s is not an integer, which doesn't make sense. Set it to 1 "
-                    "for optimum performances." % var,
-                    # RuntimeWarning,
-                )
+            add_startup_warning(log,
+                                "Your env. variable %s is not an integer, which doesn't make sense. Set it to 1 "
+                                "for optimum performances." % var)
 
     else:
-        if threeML_config.logging.startup_warnings:
-            log.warning(
-                "Env. variable %s is not set. Please set it to 1 for optimal performances in 3ML"
-                % var
-                #            RuntimeWarning,
-            )
-
+        add_startup_warning(log,
+                            "Env. variable %s is not set. Please set it to 1 for optimal performances in 3ML"
+                % var)
 
 del os
 del Path

--- a/threeML/__init__.py
+++ b/threeML/__init__.py
@@ -152,11 +152,11 @@ def get_available_plugins():
 
 
 def _display_plugin_traceback(plugin):
-    add_startup_warning("#############################################################")
-    add_startup_warning("\nCouldn't import plugin %s" % plugin)
-    add_startup_warning("\nTraceback:\n")
-    add_startup_warning(_not_working_plugins[plugin])
-    add_startup_warning("#############################################################")
+    add_startup_warning(log, "#############################################################")
+    add_startup_warning(log, "\nCouldn't import plugin %s" % plugin)
+    add_startup_warning(log, "\nTraceback:\n")
+    add_startup_warning(log, _not_working_plugins[plugin])
+    add_startup_warning(log, "#############################################################")
 
 def is_plugin_available(plugin):
     """Test whether the plugin for the provided instrument is available.

--- a/threeML/__init__.py
+++ b/threeML/__init__.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 # We import matplotlib first, because we need control on the backend
 # Indeed, if no DISPLAY variable is set, matplotlib 2.0 crashes (at the moment, 05/26/2017)
 import os
@@ -29,16 +32,11 @@ from pathlib import Path
 # Import everything from astromodels
 from astromodels import *
 
-from .io.logging import setup_logger
-
 from .config import (
     threeML_config,
     show_configuration,
     get_current_configuration_copy,
 )
-
-log = setup_logger(__name__)
-log.propagate = False
 
 if threeML_config["logging"]["startup_warnings"]:
     log.info("Starting 3ML!")

--- a/threeML/__init__.py
+++ b/threeML/__init__.py
@@ -37,6 +37,8 @@ from .config import (
     get_current_configuration_copy,
 )
 
+log = logging.getLogger(__name__)
+
 if threeML_config["logging"]["startup_warnings"]:
     log.info("Starting 3ML!")
     log.warning("WARNINGs here are [red]NOT[/red] errors")

--- a/threeML/__init__.py
+++ b/threeML/__init__.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 # We import matplotlib first, because we need control on the backend
 # Indeed, if no DISPLAY variable is set, matplotlib 2.0 crashes (at the moment, 05/26/2017)

--- a/threeML/analysis_results.py
+++ b/threeML/analysis_results.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import collections
 import datetime
@@ -46,7 +45,7 @@ from threeML.random_variates import RandomVariates
 if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
-
+log = logging.getLogger(__name__)
 
 _rich_console = Console()
 

--- a/threeML/analysis_results.py
+++ b/threeML/analysis_results.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import collections
 import datetime
 import functools
@@ -32,7 +35,7 @@ from threeML.io.hdf5_utils import (
     recursively_load_dict_contents_from_group,
     recursively_save_dict_contents_to_group,
 )
-from threeML.io.logging import setup_logger
+
 from threeML.io.package_data import get_path_of_data_file
 from threeML.io.results_table import ResultsTable
 from threeML.io.rich_display import display
@@ -43,7 +46,7 @@ from threeML.random_variates import RandomVariates
 if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
-log = setup_logger(__name__)
+
 
 _rich_console = Console()
 

--- a/threeML/bayesian/autoemcee_sampler.py
+++ b/threeML/bayesian/autoemcee_sampler.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import time
 
 import numpy as np
@@ -5,7 +8,7 @@ from astromodels import use_astromodels_memoization
 
 from threeML.bayesian.sampler_base import UnitCubeSampler
 from threeML.config.config import threeML_config
-from threeML.io.logging import setup_logger
+
 
 try:
     import autoemcee
@@ -37,7 +40,7 @@ except Exception:
 # un_logger = logging.getLogger("ultranest")
 # un_logger.propagate = False
 
-log = setup_logger(__name__)
+
 
 
 class AutoEmceeSampler(UnitCubeSampler):

--- a/threeML/bayesian/autoemcee_sampler.py
+++ b/threeML/bayesian/autoemcee_sampler.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import time
 
@@ -40,7 +39,7 @@ except Exception:
 # un_logger = logging.getLogger("ultranest")
 # un_logger.propagate = False
 
-
+log = logging.getLogger(__name__)
 
 
 class AutoEmceeSampler(UnitCubeSampler):

--- a/threeML/bayesian/bayesian_analysis.py
+++ b/threeML/bayesian/bayesian_analysis.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 from typing import Dict, Optional
 
@@ -13,7 +12,7 @@ from threeML.config import threeML_config
 from threeML.data_list import DataList
 
 
-
+log = logging.getLogger(__name__)
 
 
 _possible_samplers = {

--- a/threeML/bayesian/bayesian_analysis.py
+++ b/threeML/bayesian/bayesian_analysis.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 from typing import Dict, Optional
 
 import numpy as np
@@ -8,9 +11,9 @@ from threeML.analysis_results import BayesianResults
 from threeML.bayesian.sampler_base import SamplerBase
 from threeML.config import threeML_config
 from threeML.data_list import DataList
-from threeML.io.logging import setup_logger
 
-log = setup_logger(__name__)
+
+
 
 
 _possible_samplers = {

--- a/threeML/bayesian/dynesty_sampler.py
+++ b/threeML/bayesian/dynesty_sampler.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import math
 from typing import Optional, Literal
@@ -26,7 +25,7 @@ except Exception:  # pragma: no cover
 else:
     has_dynesty = True
 
-
+log = logging.getLogger(__name__)
 
 
 def fill_docs(**kwargs):

--- a/threeML/bayesian/dynesty_sampler.py
+++ b/threeML/bayesian/dynesty_sampler.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import math
 from typing import Optional, Literal
 from packaging.version import Version
@@ -7,7 +10,7 @@ from astromodels import use_astromodels_memoization
 
 from threeML.bayesian.sampler_base import UnitCubeSampler
 from threeML.config.config import threeML_config
-from threeML.io.logging import setup_logger
+
 from threeML.parallel.parallel_client import ParallelClient
 
 try:
@@ -23,7 +26,7 @@ except Exception:  # pragma: no cover
 else:
     has_dynesty = True
 
-log = setup_logger(__name__)
+
 
 
 def fill_docs(**kwargs):

--- a/threeML/bayesian/emcee_sampler.py
+++ b/threeML/bayesian/emcee_sampler.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 from typing import Optional
 
@@ -13,7 +12,7 @@ from threeML.io.detect_notebook import is_inside_notebook
 
 from threeML.parallel.parallel_client import ParallelClient
 
-
+log = logging.getLogger(__name__)
 
 
 class EmceeSampler(MCMCSampler):

--- a/threeML/bayesian/emcee_sampler.py
+++ b/threeML/bayesian/emcee_sampler.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 from typing import Optional
 
 import emcee
@@ -7,10 +10,10 @@ from astromodels import use_astromodels_memoization
 from threeML.bayesian.sampler_base import MCMCSampler
 from threeML.config import threeML_config
 from threeML.io.detect_notebook import is_inside_notebook
-from threeML.io.logging import setup_logger
+
 from threeML.parallel.parallel_client import ParallelClient
 
-log = setup_logger(__name__)
+
 
 
 class EmceeSampler(MCMCSampler):

--- a/threeML/bayesian/multinest_sampler.py
+++ b/threeML/bayesian/multinest_sampler.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import shutil
 from pathlib import Path
@@ -40,7 +39,7 @@ try:
 except Exception:
     using_mpi = False
 
-
+log = logging.getLogger(__name__)
 
 
 class MultiNestSampler(UnitCubeSampler):

--- a/threeML/bayesian/multinest_sampler.py
+++ b/threeML/bayesian/multinest_sampler.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import shutil
 from pathlib import Path
 from typing import Optional
@@ -9,7 +12,7 @@ from astromodels.core.model import Model
 from threeML.bayesian.sampler_base import UnitCubeSampler
 from threeML.config.config import threeML_config
 from threeML.data_list import DataList
-from threeML.io.logging import setup_logger
+
 
 try:
     import pymultinest
@@ -37,7 +40,7 @@ try:
 except Exception:
     using_mpi = False
 
-log = setup_logger(__name__)
+
 
 
 class MultiNestSampler(UnitCubeSampler):

--- a/threeML/bayesian/nautilus_sampler.py
+++ b/threeML/bayesian/nautilus_sampler.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import inspect
 
 import numpy as np
@@ -5,7 +8,7 @@ from astromodels import use_astromodels_memoization
 
 from threeML.bayesian.sampler_base import UnitCubeSampler
 from threeML.config.config import threeML_config
-from threeML.io.logging import setup_logger
+
 
 try:
     import nautilus
@@ -32,7 +35,7 @@ try:
 except ModuleNotFoundError:
     using_mpi: bool = False
 
-log = setup_logger(__name__)
+
 
 
 class NautilusSampler(UnitCubeSampler):

--- a/threeML/bayesian/nautilus_sampler.py
+++ b/threeML/bayesian/nautilus_sampler.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import inspect
 
@@ -35,7 +34,7 @@ try:
 except ModuleNotFoundError:
     using_mpi: bool = False
 
-
+log = logging.getLogger(__name__)
 
 
 class NautilusSampler(UnitCubeSampler):

--- a/threeML/bayesian/sampler_base.py
+++ b/threeML/bayesian/sampler_base.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import abc
 import collections
@@ -38,7 +37,7 @@ from threeML.utils.numba_utils import nb_sum
 from threeML.utils.spectrum.share_spectrum import ShareSpectrum
 from threeML.utils.statistics.stats_tools import aic, bic, dic
 
-
+log = logging.getLogger(__name__)
 
 
 class SamplerBase(metaclass=abc.ABCMeta):

--- a/threeML/bayesian/sampler_base.py
+++ b/threeML/bayesian/sampler_base.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import abc
 import collections
 import math
@@ -30,12 +33,12 @@ from astromodels.functions.function import ModelAssertionViolation
 
 from threeML.analysis_results import BayesianResults
 from threeML.data_list import DataList
-from threeML.io.logging import setup_logger
+
 from threeML.utils.numba_utils import nb_sum
 from threeML.utils.spectrum.share_spectrum import ShareSpectrum
 from threeML.utils.statistics.stats_tools import aic, bic, dic
 
-log = setup_logger(__name__)
+
 
 
 class SamplerBase(metaclass=abc.ABCMeta):

--- a/threeML/bayesian/ultranest_sampler.py
+++ b/threeML/bayesian/ultranest_sampler.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import logging
 import os
@@ -42,7 +41,7 @@ except Exception:
 un_logger = logging.getLogger("ultranest")
 un_logger.propagate = False
 
-
+log = logging.getLogger(__name__)
 
 
 class UltraNestSampler(UnitCubeSampler):

--- a/threeML/bayesian/ultranest_sampler.py
+++ b/threeML/bayesian/ultranest_sampler.py
@@ -1,6 +1,4 @@
 import logging
-
-import logging
 import os
 from typing import Optional
 

--- a/threeML/bayesian/ultranest_sampler.py
+++ b/threeML/bayesian/ultranest_sampler.py
@@ -1,4 +1,7 @@
 import logging
+log = logging.getLogger(__name__)
+
+import logging
 import os
 from typing import Optional
 
@@ -7,7 +10,7 @@ from astromodels import use_astromodels_memoization
 
 from threeML.bayesian.sampler_base import UnitCubeSampler
 from threeML.config.config import threeML_config
-from threeML.io.logging import setup_logger
+
 
 try:
     import ultranest
@@ -39,7 +42,7 @@ except Exception:
 un_logger = logging.getLogger("ultranest")
 un_logger.propagate = False
 
-log = setup_logger(__name__)
+
 
 
 class UltraNestSampler(UnitCubeSampler):

--- a/threeML/bayesian/zeus_sampler.py
+++ b/threeML/bayesian/zeus_sampler.py
@@ -1,9 +1,12 @@
+import logging
+log = logging.getLogger(__name__)
+
 import numpy as np
 from astromodels import use_astromodels_memoization
 
 from threeML.bayesian.sampler_base import MCMCSampler
 from threeML.config.config import threeML_config
-from threeML.io.logging import setup_logger
+
 from threeML.parallel.parallel_client import ParallelClient
 
 try:
@@ -34,7 +37,7 @@ try:
 except Exception:
     using_mpi = False
 
-log = setup_logger(__name__)
+
 
 
 class ZeusSampler(MCMCSampler):

--- a/threeML/bayesian/zeus_sampler.py
+++ b/threeML/bayesian/zeus_sampler.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import numpy as np
 from astromodels import use_astromodels_memoization
@@ -37,7 +36,7 @@ try:
 except Exception:
     using_mpi = False
 
-
+log = logging.getLogger(__name__)
 
 
 class ZeusSampler(MCMCSampler):

--- a/threeML/catalogs/FermiGBM.py
+++ b/threeML/catalogs/FermiGBM.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import numpy
 from astromodels import (
     Band,
@@ -11,12 +14,12 @@ from astromodels import (
 from threeML.config.config import threeML_config
 from threeML.io.dict_with_pretty_print import DictWithPrettyPrint
 from threeML.io.get_heasarc_table_as_pandas import get_heasarc_table_as_pandas
-from threeML.io.logging import setup_logger
+
 
 from .catalog_utils import _gbm_and_lle_valid_source_check
 from .VirtualObservatoryCatalog import VirtualObservatoryCatalog
 
-log = setup_logger(__name__)
+
 
 
 class FermiGBMBurstCatalog(VirtualObservatoryCatalog):

--- a/threeML/catalogs/FermiGBM.py
+++ b/threeML/catalogs/FermiGBM.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import numpy
 from astromodels import (
@@ -19,7 +18,7 @@ from threeML.io.get_heasarc_table_as_pandas import get_heasarc_table_as_pandas
 from .catalog_utils import _gbm_and_lle_valid_source_check
 from .VirtualObservatoryCatalog import VirtualObservatoryCatalog
 
-
+log = logging.getLogger(__name__)
 
 
 class FermiGBMBurstCatalog(VirtualObservatoryCatalog):

--- a/threeML/catalogs/FermiLAT.py
+++ b/threeML/catalogs/FermiLAT.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import re
 import os
@@ -29,7 +28,7 @@ except Exception:
     have_fermipy = False
 
 
-
+log = logging.getLogger(__name__)
 
 fgl_types = {
     "agn": "other non-blazar active galaxy",

--- a/threeML/catalogs/FermiLAT.py
+++ b/threeML/catalogs/FermiLAT.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import re
 import os
 from builtins import map, str
@@ -9,7 +12,7 @@ from astropy.table import Table
 
 from threeML.config.config import threeML_config
 from threeML.io.get_heasarc_table_as_pandas import get_heasarc_table_as_pandas
-from threeML.io.logging import setup_logger
+
 
 from .catalog_utils import (
     ModelFromFGL,
@@ -26,7 +29,7 @@ except Exception:
     have_fermipy = False
 
 
-log = setup_logger(__name__)
+
 
 fgl_types = {
     "agn": "other non-blazar active galaxy",

--- a/threeML/catalogs/FermiLLE.py
+++ b/threeML/catalogs/FermiLLE.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 from threeML.config.config import threeML_config
 from threeML.io.get_heasarc_table_as_pandas import get_heasarc_table_as_pandas
@@ -8,7 +7,7 @@ from threeML.io.get_heasarc_table_as_pandas import get_heasarc_table_as_pandas
 from .catalog_utils import _gbm_and_lle_valid_source_check
 from .VirtualObservatoryCatalog import VirtualObservatoryCatalog
 
-
+log = logging.getLogger(__name__)
 
 
 class FermiLLEBurstCatalog(VirtualObservatoryCatalog):

--- a/threeML/catalogs/FermiLLE.py
+++ b/threeML/catalogs/FermiLLE.py
@@ -1,11 +1,14 @@
+import logging
+log = logging.getLogger(__name__)
+
 from threeML.config.config import threeML_config
 from threeML.io.get_heasarc_table_as_pandas import get_heasarc_table_as_pandas
-from threeML.io.logging import setup_logger
+
 
 from .catalog_utils import _gbm_and_lle_valid_source_check
 from .VirtualObservatoryCatalog import VirtualObservatoryCatalog
 
-log = setup_logger(__name__)
+
 
 
 class FermiLLEBurstCatalog(VirtualObservatoryCatalog):

--- a/threeML/catalogs/Swift.py
+++ b/threeML/catalogs/Swift.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import re
 import requests
 from requests.adapters import HTTPAdapter
@@ -11,10 +14,10 @@ import pandas as pd
 from threeML.catalogs.VirtualObservatoryCatalog import VirtualObservatoryCatalog
 from threeML.config.config import threeML_config
 from threeML.io.get_heasarc_table_as_pandas import get_heasarc_table_as_pandas
-from threeML.io.logging import setup_logger
+
 from threeML.io.rich_display import display
 
-log = setup_logger(__name__)
+
 
 _gcn_match = re.compile(r"^\d{4}GCN\D?\.*(\d*)\.*\d\D$")
 _trigger_name_match = re.compile(r"^GRB \d{6}[A-Z]$")

--- a/threeML/catalogs/Swift.py
+++ b/threeML/catalogs/Swift.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import re
 import requests
@@ -17,7 +16,7 @@ from threeML.io.get_heasarc_table_as_pandas import get_heasarc_table_as_pandas
 
 from threeML.io.rich_display import display
 
-
+log = logging.getLogger(__name__)
 
 _gcn_match = re.compile(r"^\d{4}GCN\D?\.*(\d*)\.*\d\D$")
 _trigger_name_match = re.compile(r"^GRB \d{6}[A-Z]$")

--- a/threeML/catalogs/VirtualObservatoryCatalog.py
+++ b/threeML/catalogs/VirtualObservatoryCatalog.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import warnings
 
 import astropy
@@ -11,10 +14,10 @@ from astroquery.vo_conesearch.exceptions import VOSError
 # from astropy.vo.client.vos_catalog import VOSCatalog
 from astroquery.vo_conesearch.vos_catalog import VOSCatalog
 
-from threeML.io.logging import setup_logger
+
 from threeML.io.network import internet_connection_is_active
 
-log = setup_logger(__name__)
+
 
 # Workaround to support astropy 4.1+
 astropy_old = True

--- a/threeML/catalogs/VirtualObservatoryCatalog.py
+++ b/threeML/catalogs/VirtualObservatoryCatalog.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import warnings
 
@@ -17,7 +16,7 @@ from astroquery.vo_conesearch.vos_catalog import VOSCatalog
 
 from threeML.io.network import internet_connection_is_active
 
-
+log = logging.getLogger(__name__)
 
 # Workaround to support astropy 4.1+
 astropy_old = True

--- a/threeML/catalogs/catalog_utils.py
+++ b/threeML/catalogs/catalog_utils.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import os
 import os.path
 import re
@@ -18,9 +21,9 @@ from astromodels.utils.angular_distance import angular_distance
 from astropy import units as u
 from astropy.stats import circmean
 
-from threeML.io.logging import setup_logger
 
-log = setup_logger(__name__)
+
+
 
 _trigger_name_match = re.compile(r"^GRB\d{9}$")
 

--- a/threeML/catalogs/catalog_utils.py
+++ b/threeML/catalogs/catalog_utils.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import os
 import os.path
@@ -23,7 +22,7 @@ from astropy.stats import circmean
 
 
 
-
+log = logging.getLogger(__name__)
 
 _trigger_name_match = re.compile(r"^GRB\d{9}$")
 

--- a/threeML/catalogs/catalog_utils.py
+++ b/threeML/catalogs/catalog_utils.py
@@ -20,8 +20,6 @@ from astromodels.utils.angular_distance import angular_distance
 from astropy import units as u
 from astropy.stats import circmean
 
-
-
 log = logging.getLogger(__name__)
 
 _trigger_name_match = re.compile(r"^GRB\d{9}$")

--- a/threeML/classicMLE/joint_likelihood.py
+++ b/threeML/classicMLE/joint_likelihood.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import collections
 import sys
 import weakref
@@ -21,7 +24,7 @@ from threeML.exceptions.custom_exceptions import (
     MinLargerMax,
     NoFitYet,
 )
-from threeML.io.logging import setup_logger
+
 from threeML.io.package_data import get_path_of_data_file
 from threeML.io.results_table import ResultsTable
 from threeML.io.table import Table
@@ -33,7 +36,7 @@ if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
 
-log = setup_logger(__name__)
+
 
 
 class ReducingNumberOfThreads(Warning):

--- a/threeML/classicMLE/joint_likelihood.py
+++ b/threeML/classicMLE/joint_likelihood.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import collections
 import sys
@@ -36,7 +35,7 @@ if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
 
-
+log = logging.getLogger(__name__)
 
 
 class ReducingNumberOfThreads(Warning):

--- a/threeML/classicMLE/joint_likelihood_set.py
+++ b/threeML/classicMLE/joint_likelihood_set.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import warnings
 from builtins import object, range
@@ -16,7 +15,7 @@ from threeML.minimizer.minimization import LocalMinimization, _Minimization, _mi
 from threeML.parallel.parallel_client import ParallelClient
 from threeML.utils.progress_bar import trange
 
-
+log = logging.getLogger(__name__)
 
 
 class JointLikelihoodSet(object):

--- a/threeML/classicMLE/joint_likelihood_set.py
+++ b/threeML/classicMLE/joint_likelihood_set.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import warnings
 from builtins import object, range
 
@@ -8,12 +11,12 @@ from astromodels import Model
 from threeML.analysis_results import AnalysisResultsSet
 from threeML.classicMLE.joint_likelihood import JointLikelihood
 from threeML.config.config import threeML_config
-from threeML.io.logging import setup_logger, silence_console_log
+from threeML.io.logging import silence_console_log
 from threeML.minimizer.minimization import LocalMinimization, _Minimization, _minimizers
 from threeML.parallel.parallel_client import ParallelClient
 from threeML.utils.progress_bar import trange
 
-log = setup_logger(__name__)
+
 
 
 class JointLikelihoodSet(object):
@@ -226,7 +229,7 @@ class JointLikelihoodSet(object):
         if threeML_config["parallel"]["use_parallel"]:
             # Parallel computation
 
-            with silence_console_log(and_progress_bars=False):
+            with silence_console_log(log, and_progress_bars=False):
                 client = ParallelClient(**options_for_parallel_computation)
 
                 results = client.execute_with_progress_bar(
@@ -238,7 +241,7 @@ class JointLikelihoodSet(object):
 
             results = []
 
-            with silence_console_log(and_progress_bars=False):
+            with silence_console_log(log, and_progress_bars=False):
                 for i in trange(self._n_iterations, desc="Goodness of fit computation"):
                     results.append(self.worker(i))
 

--- a/threeML/classicMLE/likelihood_ratio_test.py
+++ b/threeML/classicMLE/likelihood_ratio_test.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -8,7 +11,7 @@ from threeML.classicMLE.joint_likelihood import JointLikelihood
 from threeML.classicMLE.joint_likelihood_set import JointLikelihoodSet
 from threeML.config import threeML_config
 from threeML.data_list import DataList
-from threeML.io.logging import setup_logger
+
 from threeML.io.package_data import get_path_of_data_file
 from threeML.plugins.OGIPLike import OGIPLike
 from threeML.utils.OGIP.pha import PHAWrite
@@ -17,7 +20,7 @@ if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
 
-log = setup_logger(__name__)
+
 
 
 class LikelihoodRatioTest:

--- a/threeML/classicMLE/likelihood_ratio_test.py
+++ b/threeML/classicMLE/likelihood_ratio_test.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -20,7 +19,7 @@ if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
 
-
+log = logging.getLogger(__name__)
 
 
 class LikelihoodRatioTest:

--- a/threeML/config/__init__.py
+++ b/threeML/config/__init__.py
@@ -1,2 +1,2 @@
-from .config import threeML_config
+from .config import threeML_config, get_path_of_user_config
 from .config_utils import get_current_configuration_copy, show_configuration

--- a/threeML/config/config.py
+++ b/threeML/config/config.py
@@ -1,13 +1,26 @@
+import os
+from pathlib import Path
+
 from omegaconf import OmegaConf
-
-from threeML.io.package_data import get_path_of_user_config
-
 from .config_structure import Config
 
 # Read the default Config
 threeML_config: Config = OmegaConf.structured(Config)
 
 # now glob the config directory
+
+def get_path_of_user_config() -> Path:
+    if os.environ.get("THREEML_CONFIG") is not None:
+        config_path: Path = Path(os.environ.get("THREEML_CONFIG"))
+
+    else:
+        config_path: Path = Path().home() / ".config" / "threeML"
+
+    if not config_path.exists():
+        config_path.mkdir(parents=True)
+
+    return config_path
+
 
 for user_config_file in get_path_of_user_config().glob("*.yml"):
     _partial_conf = OmegaConf.load(user_config_file)

--- a/threeML/config/config.py
+++ b/threeML/config/config.py
@@ -9,6 +9,7 @@ threeML_config: Config = OmegaConf.structured(Config)
 
 # now glob the config directory
 
+
 def get_path_of_user_config() -> Path:
     if os.environ.get("THREEML_CONFIG") is not None:
         config_path: Path = Path(os.environ.get("THREEML_CONFIG"))

--- a/threeML/config/config_structure.py
+++ b/threeML/config/config_structure.py
@@ -25,7 +25,6 @@ class Logging:
     usr: bool = "on"
     console: bool = "on"
     level: LoggingLevel = LoggingLevel.INFO
-    startup_warnings: bool = "on"
 
 
 @dataclass

--- a/threeML/config/config_utils.py
+++ b/threeML/config/config_utils.py
@@ -1,3 +1,7 @@
+import logging
+
+log = logging.getLogger(__name__)
+
 from pathlib import Path
 from typing import Optional
 
@@ -5,15 +9,7 @@ from omegaconf import OmegaConf
 from omegaconf.dictconfig import DictConfig
 from rich.tree import Tree
 
-from threeML.io.package_data import get_path_of_user_config
-
-from .config import threeML_config
-
-# FIXME: These lines were moved to local imports withing functions since
-# they were causing a circular import. The config module needs the logging setup,
-# and the logging setup needs the config module.
-# from threeML.io.logging import setup_logger
-# log = setup_logger(__name__)
+from .config import threeML_config, get_path_of_user_config
 
 
 def recurse_dict(d, tree):
@@ -56,9 +52,6 @@ def show_configuration(sub_menu: Optional[str] = None):
         else:
             msg = f"{sub_menu} is not in the threeml configuration"
 
-            from threeML.io.logging import setup_logger
-
-            log = setup_logger(__name__)
             log.error(msg)
 
             raise AssertionError(msg)
@@ -101,10 +94,6 @@ def get_value(name, user_value, par_type, config_value):
     :param config_value: value in config
     :returns: parameter value
     """
-
-    from threeML.io.logging import setup_logger
-
-    log = setup_logger(__name__)
 
     if user_value is not None:
         value = user_value

--- a/threeML/config/config_utils.py
+++ b/threeML/config/config_utils.py
@@ -1,7 +1,5 @@
 import logging
 
-log = logging.getLogger(__name__)
-
 from pathlib import Path
 from typing import Optional
 
@@ -11,6 +9,7 @@ from rich.tree import Tree
 
 from .config import threeML_config, get_path_of_user_config
 
+log = logging.getLogger(__name__)
 
 def recurse_dict(d, tree):
     for k, v in d.items():

--- a/threeML/config/config_utils.py
+++ b/threeML/config/config_utils.py
@@ -11,6 +11,7 @@ from .config import threeML_config, get_path_of_user_config
 
 log = logging.getLogger(__name__)
 
+
 def recurse_dict(d, tree):
     for k, v in d.items():
         if isinstance(v, dict) or isinstance(v, DictConfig):

--- a/threeML/data/doc_config.yml
+++ b/threeML/data/doc_config.yml
@@ -1,5 +1,2 @@
-logging:
-  startup_warnings: off
-
 plotting:
   mplstyle: "threeml_docs.mplstyle"

--- a/threeML/io/calculate_flux.py
+++ b/threeML/io/calculate_flux.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 __author__ = "grburgess"
 
 import collections
@@ -5,13 +8,13 @@ import collections
 import numpy as np
 import pandas as pd
 
-from threeML.io.logging import setup_logger
+
 from threeML.utils.fitted_objects.fitted_point_sources import (
     FittedPointSourceSpectralHandler,
 )
 from threeML.utils.progress_bar import tqdm
 
-log = setup_logger(__name__)
+
 
 
 def _setup_analysis_dictionaries(

--- a/threeML/io/calculate_flux.py
+++ b/threeML/io/calculate_flux.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 __author__ = "grburgess"
 
@@ -14,7 +13,7 @@ from threeML.utils.fitted_objects.fitted_point_sources import (
 )
 from threeML.utils.progress_bar import tqdm
 
-
+log = logging.getLogger(__name__)
 
 
 def _setup_analysis_dictionaries(

--- a/threeML/io/download_from_http.py
+++ b/threeML/io/download_from_http.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import os
 import re
@@ -20,7 +19,7 @@ from threeML.io.file_utils import (
 
 from threeML.utils.progress_bar import tqdm
 
-
+log = logging.getLogger(__name__)
 
 
 class RemoteDirectoryNotFound(IOError):

--- a/threeML/io/download_from_http.py
+++ b/threeML/io/download_from_http.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import os
 import re
 from builtins import object
@@ -14,10 +17,10 @@ from threeML.io.file_utils import (
     path_exists_and_is_directory,
     sanitize_filename,
 )
-from threeML.io.logging import setup_logger
+
 from threeML.utils.progress_bar import tqdm
 
-log = setup_logger(__name__)
+
 
 
 class RemoteDirectoryNotFound(IOError):

--- a/threeML/io/file_utils.py
+++ b/threeML/io/file_utils.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import os
 import shutil
 import tempfile
@@ -6,9 +9,9 @@ from builtins import str
 from contextlib import contextmanager
 from pathlib import Path
 
-from threeML.io.logging import setup_logger
 
-log = setup_logger(__name__)
+
+
 
 
 def sanitize_filename(filename, abspath: bool = False) -> Path:

--- a/threeML/io/file_utils.py
+++ b/threeML/io/file_utils.py
@@ -8,8 +8,6 @@ from builtins import str
 from contextlib import contextmanager
 from pathlib import Path
 
-
-
 log = logging.getLogger(__name__)
 
 

--- a/threeML/io/file_utils.py
+++ b/threeML/io/file_utils.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import os
 import shutil
@@ -11,7 +10,7 @@ from pathlib import Path
 
 
 
-
+log = logging.getLogger(__name__)
 
 
 def sanitize_filename(filename, abspath: bool = False) -> Path:

--- a/threeML/io/fits_file.py
+++ b/threeML/io/fits_file.py
@@ -5,8 +5,6 @@ import numpy as np
 from astropy.io import fits
 from importlib.metadata import version
 
-
-
 log = logging.getLogger(__name__)
 
 # From https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/node20.html

--- a/threeML/io/fits_file.py
+++ b/threeML/io/fits_file.py
@@ -1,11 +1,14 @@
+import logging
+log = logging.getLogger(__name__)
+
 import astropy.units as u
 import numpy as np
 from astropy.io import fits
 from importlib.metadata import version
 
-from threeML.io.logging import setup_logger
 
-log = setup_logger(__name__)
+
+
 
 # From https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/node20.html
 # Codes for the data type of binary table columns and/or for the

--- a/threeML/io/fits_file.py
+++ b/threeML/io/fits_file.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import astropy.units as u
 import numpy as np
@@ -8,7 +7,7 @@ from importlib.metadata import version
 
 
 
-
+log = logging.getLogger(__name__)
 
 # From https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/node20.html
 # Codes for the data type of binary table columns and/or for the

--- a/threeML/io/get_heasarc_table_as_pandas.py
+++ b/threeML/io/get_heasarc_table_as_pandas.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import codecs
 import datetime
@@ -21,7 +20,7 @@ from threeML.io.file_utils import (
 )
 
 
-
+log = logging.getLogger(__name__)
 
 
 def get_heasarc_table_as_pandas(heasarc_table_name, update=False, cache_time_days=1):

--- a/threeML/io/get_heasarc_table_as_pandas.py
+++ b/threeML/io/get_heasarc_table_as_pandas.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import codecs
 import datetime
 import requests
@@ -16,9 +19,9 @@ from threeML.io.file_utils import (
     if_directory_not_existing_then_make,
     sanitize_filename,
 )
-from threeML.io.logging import setup_logger
 
-log = setup_logger(__name__)
+
+
 
 
 def get_heasarc_table_as_pandas(heasarc_table_name, update=False, cache_time_days=1):

--- a/threeML/io/logging.py
+++ b/threeML/io/logging.py
@@ -363,12 +363,24 @@ def setup_logger(name: str) -> logging.Logger:
     return log
 
 # Capture all startup warnings and log them on demand
+
+
 _startup_warnings = []
+
 
 def add_startup_warning(logger, msg, level = logging.WARNING):
     fn, lno, func, sinfo = logger.findCaller(stacklevel=2)
-    record = logger.makeRecord(logger.name, level, fn, lno, msg, (), None, func=func, sinfo=sinfo)
+    record = logger.makeRecord(logger.name,
+                               level,
+                               fn,
+                               lno,
+                               msg,
+                               (),
+                               None,
+                               func=func,
+                               sinfo=sinfo)
     _startup_warnings.append(record)
+
 
 def log_threeml_startup_warnings(logger):
     for w in _startup_warnings:

--- a/threeML/io/logging.py
+++ b/threeML/io/logging.py
@@ -20,6 +20,8 @@ from rich.theme import Theme
 
 from threeML.config.config import threeML_config
 
+logger = logging.getLogger(__name__)
+
 # set up the console logging
 
 
@@ -359,3 +361,15 @@ def setup_logger(name: str) -> logging.Logger:
         log.addHandler(threeML_usr_log_handler)
 
     return log
+
+# Capture all startup warnings and log them on demand
+_startup_warnings = []
+
+def add_startup_warning(logger, msg, level = logging.WARNING):
+    fn, lno, func, sinfo = logger.findCaller(stacklevel=2)
+    record = logger.makeRecord(logger.name, level, fn, lno, msg, (), None, func=func, sinfo=sinfo)
+    _startup_warnings.append(record)
+
+def log_startup_warnings(logger):
+    for w in _startup_warnings:
+        logger.handle(w)

--- a/threeML/io/logging.py
+++ b/threeML/io/logging.py
@@ -368,7 +368,7 @@ def setup_logger(name: str) -> logging.Logger:
 _startup_warnings = []
 
 
-def add_startup_warning(logger, msg, level = logging.WARNING):
+def add_startup_warning(logger, msg, level=logging.WARNING):
     fn, lno, func, sinfo = logger.findCaller(stacklevel=2)
     record = logger.makeRecord(logger.name,
                                level,

--- a/threeML/io/logging.py
+++ b/threeML/io/logging.py
@@ -358,7 +358,4 @@ def setup_logger(name: str) -> logging.Logger:
     if threeML_config["logging"]["usr"]:
         log.addHandler(threeML_usr_log_handler)
 
-    # we do not want to duplicate teh messages in the parents
-    log.propagate = False
-
     return log

--- a/threeML/io/logging.py
+++ b/threeML/io/logging.py
@@ -370,6 +370,6 @@ def add_startup_warning(logger, msg, level = logging.WARNING):
     record = logger.makeRecord(logger.name, level, fn, lno, msg, (), None, func=func, sinfo=sinfo)
     _startup_warnings.append(record)
 
-def log_startup_warnings(logger):
+def log_threeml_startup_warnings(logger):
     for w in _startup_warnings:
         logger.handle(w)

--- a/threeML/io/logging.py
+++ b/threeML/io/logging.py
@@ -312,13 +312,11 @@ def debug_mode():
 
 
 @contextmanager
-def silence_console_log(and_progress_bars=True):
+def silence_console_log(logger, and_progress_bars=True):
     """Temporarily silence the console and progress bars."""
-    current_console_logging_level = threeML_console_log_handler.level
-    current_usr_logging_level = threeML_usr_log_handler.level
+    current_console_logging_level = logger.level
 
-    threeML_console_log_handler.setLevel(logging.CRITICAL)
-    threeML_usr_log_handler.setLevel(logging.CRITICAL)
+    logger.setLevel(logging.CRITICAL)
 
     if and_progress_bars:
         progress_state = threeML_config.interface.progress_bars
@@ -329,8 +327,7 @@ def silence_console_log(and_progress_bars=True):
         yield
 
     finally:
-        threeML_console_log_handler.setLevel(current_console_logging_level)
-        threeML_usr_log_handler.setLevel(current_usr_logging_level)
+        logger.setLevel(current_console_logging_level)
 
         if and_progress_bars:
             threeML_config.interface.progress_bars = progress_state

--- a/threeML/io/network.py
+++ b/threeML/io/network.py
@@ -1,12 +1,11 @@
 import logging
-log = logging.getLogger(__name__)
 
 import os
 import socket
 import requests
 
 
-
+log = logging.getLogger(__name__)
 
 
 def internet_connection_is_active():

--- a/threeML/io/network.py
+++ b/threeML/io/network.py
@@ -1,9 +1,12 @@
+import logging
+log = logging.getLogger(__name__)
+
 import os
 import socket
 import requests
-from threeML.io.logging import setup_logger
 
-log = setup_logger(__name__)
+
+
 
 
 def internet_connection_is_active():

--- a/threeML/io/package_data.py
+++ b/threeML/io/package_data.py
@@ -55,19 +55,6 @@ def get_path_of_user_dir() -> Path:
     return user_dir
 
 
-def get_path_of_user_config() -> Path:
-    if os.environ.get("THREEML_CONFIG") is not None:
-        config_path: Path = Path(os.environ.get("THREEML_CONFIG"))
-
-    else:
-        config_path: Path = Path().home() / ".config" / "threeML"
-
-    if not config_path.exists():
-        config_path.mkdir(parents=True)
-
-    return config_path
-
-
 def get_user_data_path():
     user_data = os.path.join(os.path.expanduser("~"), ".threeml", "data")
 
@@ -85,5 +72,4 @@ __all__ = [
     "get_path_of_data_file",
     "get_path_of_data_dir",
     "get_path_of_user_dir",
-    "get_path_of_user_config",
 ]

--- a/threeML/io/plotting/data_residual_plot.py
+++ b/threeML/io/plotting/data_residual_plot.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -14,7 +13,7 @@ if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
 
-
+log = logging.getLogger(__name__)
 
 
 class ResidualPlot:

--- a/threeML/io/plotting/data_residual_plot.py
+++ b/threeML/io/plotting/data_residual_plot.py
@@ -1,9 +1,12 @@
+import logging
+log = logging.getLogger(__name__)
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.ticker import MaxNLocator
 
 from threeML.config.config import threeML_config
-from threeML.io.logging import setup_logger
+
 from threeML.io.package_data import get_path_of_data_file
 from threeML.io.plotting.step_plot import step_plot
 
@@ -11,7 +14,7 @@ if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
 
-log = setup_logger(__name__)
+
 
 
 class ResidualPlot:

--- a/threeML/io/plotting/model_plot.py
+++ b/threeML/io/plotting/model_plot.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 __author__ = "grburgess"
 
 import astropy.units as u
@@ -10,7 +13,7 @@ from threeML.io.calculate_flux import (
     _collect_sums_into_dictionaries,
     _setup_analysis_dictionaries,
 )
-from threeML.io.logging import setup_logger
+
 from threeML.io.package_data import get_path_of_data_file
 from threeML.io.plotting.cmap_cycle import cmap_intervals
 
@@ -18,7 +21,7 @@ if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
 
-log = setup_logger(__name__)
+
 
 
 def plot_point_source_spectra(*analysis_results, **kwargs):

--- a/threeML/io/plotting/model_plot.py
+++ b/threeML/io/plotting/model_plot.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 __author__ = "grburgess"
 
@@ -21,7 +20,7 @@ if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
 
-
+log = logging.getLogger(__name__)
 
 
 def plot_point_source_spectra(*analysis_results, **kwargs):

--- a/threeML/io/plotting/post_process_data_plots.py
+++ b/threeML/io/plotting/post_process_data_plots.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import colormaps
@@ -22,7 +25,7 @@ except Exception:
 from threeML.config.config import threeML_config
 from threeML.config.plotting_structure import BinnedSpectrumPlot
 from threeML.exceptions.custom_exceptions import custom_warnings
-from threeML.io.logging import setup_logger
+
 from threeML.io.package_data import get_path_of_data_file
 from threeML.io.plotting.cmap_cycle import cmap_intervals
 from threeML.io.plotting.data_residual_plot import ResidualPlot
@@ -30,7 +33,7 @@ from threeML.io.plotting.data_residual_plot import ResidualPlot
 if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
-log = setup_logger(__name__)
+
 
 # This file contains plots which are plotted in data space after a model has been
 # assigned to the plugin.

--- a/threeML/io/plotting/post_process_data_plots.py
+++ b/threeML/io/plotting/post_process_data_plots.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -33,7 +32,7 @@ from threeML.io.plotting.data_residual_plot import ResidualPlot
 if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
-
+log = logging.getLogger(__name__)
 
 # This file contains plots which are plotted in data space after a model has been
 # assigned to the plugin.

--- a/threeML/io/uncertainty_formatter.py
+++ b/threeML/io/uncertainty_formatter.py
@@ -1,11 +1,14 @@
+import logging
+log = logging.getLogger(__name__)
+
 import re
 
 import numpy as np
 import uncertainties
 
-from threeML.io.logging import setup_logger
 
-log = setup_logger(__name__)
+
+
 
 
 def interval_to_errors(value, low_bound, hi_bound):

--- a/threeML/io/uncertainty_formatter.py
+++ b/threeML/io/uncertainty_formatter.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import re
 
@@ -8,7 +7,7 @@ import uncertainties
 
 
 
-
+log = logging.getLogger(__name__)
 
 
 def interval_to_errors(value, low_bound, hi_bound):

--- a/threeML/io/uncertainty_formatter.py
+++ b/threeML/io/uncertainty_formatter.py
@@ -5,8 +5,6 @@ import re
 import numpy as np
 import uncertainties
 
-
-
 log = logging.getLogger(__name__)
 
 

--- a/threeML/minimizer/ROOT_minimizer.py
+++ b/threeML/minimizer/ROOT_minimizer.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import ctypes
 from builtins import range, zip
@@ -15,7 +14,7 @@ from threeML.minimizer.minimization import (
 )
 
 
-
+log = logging.getLogger(__name__)
 
 # These are the status returned by Minuit
 #     status = 1    : Covariance was made pos defined

--- a/threeML/minimizer/ROOT_minimizer.py
+++ b/threeML/minimizer/ROOT_minimizer.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import ctypes
 from builtins import range, zip
 
@@ -10,9 +13,9 @@ from threeML.minimizer.minimization import (
     FitFailed,
     LocalMinimizer,
 )
-from threeML.io.logging import setup_logger
 
-log = setup_logger(__name__)
+
+
 
 # These are the status returned by Minuit
 #     status = 1    : Covariance was made pos defined

--- a/threeML/minimizer/grid_minimizer.py
+++ b/threeML/minimizer/grid_minimizer.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import collections
 import itertools
 from builtins import str
@@ -6,11 +9,11 @@ import numpy as np
 from astromodels import Parameter
 
 from threeML.config.config import threeML_config
-from threeML.io.logging import setup_logger
+
 from threeML.minimizer.minimization import GlobalMinimizer
 from threeML.utils.progress_bar import tqdm
 
-log = setup_logger(__name__)
+
 
 
 class AllFitFailed(RuntimeError):

--- a/threeML/minimizer/grid_minimizer.py
+++ b/threeML/minimizer/grid_minimizer.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import collections
 import itertools
@@ -13,7 +12,7 @@ from threeML.config.config import threeML_config
 from threeML.minimizer.minimization import GlobalMinimizer
 from threeML.utils.progress_bar import tqdm
 
-
+log = logging.getLogger(__name__)
 
 
 class AllFitFailed(RuntimeError):

--- a/threeML/minimizer/minimization.py
+++ b/threeML/minimizer/minimization.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import collections
 import math
 from builtins import object, range, str, zip
@@ -8,7 +11,7 @@ import scipy.optimize
 
 from threeML.config.config import threeML_config
 from threeML.exceptions.custom_exceptions import custom_warnings
-from threeML.io.logging import setup_logger
+
 from threeML.utils.differentiation import ParameterOnBoundary, get_hessian
 from threeML.utils.progress_bar import tqdm
 
@@ -16,7 +19,7 @@ from threeML.utils.progress_bar import tqdm
 
 custom_warnings.simplefilter("always", RuntimeWarning)
 
-log = setup_logger(__name__)
+
 
 # Special constants
 FIT_FAILED = 1e12

--- a/threeML/minimizer/minimization.py
+++ b/threeML/minimizer/minimization.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import collections
 import math
@@ -19,7 +18,7 @@ from threeML.utils.progress_bar import tqdm
 
 custom_warnings.simplefilter("always", RuntimeWarning)
 
-
+log = logging.getLogger(__name__)
 
 # Special constants
 FIT_FAILED = 1e12

--- a/threeML/minimizer/minimization.py
+++ b/threeML/minimizer/minimization.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import scipy.optimize
 
+from threeML import add_startup_warning
 from threeML.config.config import threeML_config
 from threeML.exceptions.custom_exceptions import custom_warnings
 
@@ -1196,8 +1197,7 @@ try:
     from threeML.minimizer.minuit_minimizer import MinuitMinimizer
 
 except ImportError:
-    if threeML_config.logging.startup_warnings:
-        log.warning("Minuit minimizer not available")
+    add_startup_warning(log, "Minuit minimizer not available")
 
 else:
     _minimizers["MINUIT"] = MinuitMinimizer
@@ -1206,8 +1206,7 @@ try:
     from threeML.minimizer.ROOT_minimizer import ROOTMinimizer
 
 except ImportError:
-    if threeML_config.logging.startup_warnings:
-        log.warning("ROOT minimizer not available")
+    add_startup_warning(log, "ROOT minimizer not available")
 
 else:
     _minimizers["ROOT"] = ROOTMinimizer
@@ -1216,8 +1215,7 @@ try:
     from threeML.minimizer.multinest_minimizer import MultinestMinimizer
 
 except ImportError:
-    if threeML_config.logging.startup_warnings:
-        log.warning("Multinest minimizer not available")
+    add_startup_warning(log, "Multinest minimizer not available")
 
 else:
     _minimizers["MULTINEST"] = MultinestMinimizer
@@ -1226,8 +1224,7 @@ try:
     from threeML.minimizer.pagmo_minimizer import PAGMOMinimizer
 
 except ImportError:
-    if threeML_config.logging.startup_warnings:
-        log.warning("PyGMO is not available")
+    add_startup_warning(log, "PyGMO is not available")
 
 else:
     _minimizers["PAGMO"] = PAGMOMinimizer
@@ -1236,8 +1233,7 @@ try:
     from threeML.minimizer.scipy_minimizer import ScipyMinimizer
 
 except ImportError:
-    if threeML_config.logging.startup_warnings:
-        log.warning("Scipy minimizer is not available")
+    add_startup_warning(log, "Scipy minimizer is not available")
 
 else:
     _minimizers["SCIPY"] = ScipyMinimizer

--- a/threeML/minimizer/minuit_minimizer.py
+++ b/threeML/minimizer/minuit_minimizer.py
@@ -1,10 +1,13 @@
+import logging
+log = logging.getLogger(__name__)
+
 import collections
 from builtins import range
 
 import numpy as np
 from iminuit import Minuit
 
-from threeML.io.logging import setup_logger
+
 from threeML.minimizer.minimization import (
     CannotComputeCovariance,
     CannotComputeErrors,
@@ -12,7 +15,7 @@ from threeML.minimizer.minimization import (
     LocalMinimizer,
 )
 
-log = setup_logger(__name__)
+
 
 
 class MINOSFailed(Exception):

--- a/threeML/minimizer/minuit_minimizer.py
+++ b/threeML/minimizer/minuit_minimizer.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import collections
 from builtins import range
@@ -15,7 +14,7 @@ from threeML.minimizer.minimization import (
     LocalMinimizer,
 )
 
-
+log = logging.getLogger(__name__)
 
 
 class MINOSFailed(Exception):

--- a/threeML/minimizer/scipy_minimizer.py
+++ b/threeML/minimizer/scipy_minimizer.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 from builtins import zip
 
@@ -11,7 +10,7 @@ import scipy.optimize
 from threeML.minimizer.minimization import FitFailed, LocalMinimizer
 from threeML.utils.differentiation import get_jacobian
 
-
+log = logging.getLogger(__name__)
 
 
 _SUPPORTED_ALGORITHMS = ["L-BFGS-B", "TNC", "SLSQP"]

--- a/threeML/minimizer/scipy_minimizer.py
+++ b/threeML/minimizer/scipy_minimizer.py
@@ -1,14 +1,17 @@
+import logging
+log = logging.getLogger(__name__)
+
 from builtins import zip
 
 import numba as nb
 import numpy as np
 import scipy.optimize
 
-from threeML.io.logging import setup_logger
+
 from threeML.minimizer.minimization import FitFailed, LocalMinimizer
 from threeML.utils.differentiation import get_jacobian
 
-log = setup_logger(__name__)
+
 
 
 _SUPPORTED_ALGORITHMS = ["L-BFGS-B", "TNC", "SLSQP"]

--- a/threeML/parallel/parallel_client.py
+++ b/threeML/parallel/parallel_client.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 # Custom warning
 import math
 import shutil
@@ -11,10 +14,10 @@ from pathlib import Path
 from typing import Optional
 
 from threeML.config.config import threeML_config
-from threeML.io.logging import setup_logger
+
 from threeML.utils.progress_bar import tqdm
 
-log = setup_logger(__name__)
+
 
 try:
     from subprocess import DEVNULL  # py3k

--- a/threeML/parallel/parallel_client.py
+++ b/threeML/parallel/parallel_client.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 # Custom warning
 import math
@@ -17,7 +16,7 @@ from threeML.config.config import threeML_config
 
 from threeML.utils.progress_bar import tqdm
 
-
+log = logging.getLogger(__name__)
 
 try:
     from subprocess import DEVNULL  # py3k

--- a/threeML/plugin_prototype.py
+++ b/threeML/plugin_prototype.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 """Define the interface for a plugin class."""
 
 import abc
@@ -6,9 +9,9 @@ from typing import Dict
 from astromodels import IndependentVariable, Model
 from astromodels.core.parameter import Parameter
 
-from threeML.io.logging import invalid_plugin_name, setup_logger
+from threeML.io.logging import invalid_plugin_name
 
-log = setup_logger(__name__)
+
 # def set_external_property(method):
 #     """
 #     Sets external property values if they exist

--- a/threeML/plugin_prototype.py
+++ b/threeML/plugin_prototype.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 """Define the interface for a plugin class."""
 
@@ -11,7 +10,7 @@ from astromodels.core.parameter import Parameter
 
 from threeML.io.logging import invalid_plugin_name
 
-
+log = logging.getLogger(__name__)
 # def set_external_property(method):
 #     """
 #     Sets external property values if they exist

--- a/threeML/plugins/DispersionSpectrumLike.py
+++ b/threeML/plugins/DispersionSpectrumLike.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import copy
 from typing import Optional, Union
 
@@ -5,7 +8,7 @@ import numpy as np
 import pandas as pd
 from astromodels import Model
 
-from threeML.io.logging import setup_logger
+
 from threeML.plugins.SpectrumLike import SpectrumLike
 from threeML.plugins.XYLike import XYLike
 from threeML.utils.OGIP.response import InstrumentResponse
@@ -15,7 +18,7 @@ from threeML.utils.spectrum.binned_spectrum import (
     ChannelSet,
 )
 
-log = setup_logger(__name__)
+
 
 __instrument_name = "General binned spectral data with energy dispersion"
 

--- a/threeML/plugins/DispersionSpectrumLike.py
+++ b/threeML/plugins/DispersionSpectrumLike.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import copy
 from typing import Optional, Union
@@ -18,7 +17,7 @@ from threeML.utils.spectrum.binned_spectrum import (
     ChannelSet,
 )
 
-
+log = logging.getLogger(__name__)
 
 __instrument_name = "General binned spectral data with energy dispersion"
 

--- a/threeML/plugins/FermiLATLike.py
+++ b/threeML/plugins/FermiLATLike.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import collections
 from dataclasses import dataclass
@@ -33,7 +32,7 @@ if threeML_config.plotting.use_threeml_style:
 __instrument_name = "Fermi LAT (standard classes)"
 
 
-
+log = logging.getLogger(__name__)
 
 
 class MyPointSource(LikelihoodComponent.GenericSource):

--- a/threeML/plugins/FermiLATLike.py
+++ b/threeML/plugins/FermiLATLike.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import collections
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,7 +19,7 @@ from matplotlib import gridspec
 from threeML.config.config import threeML_config
 from threeML.config.plotting_structure import BinnedSpectrumPlot
 from threeML.io.file_utils import get_random_unique_name
-from threeML.io.logging import setup_logger
+
 from threeML.io.package_data import get_path_of_data_file
 from threeML.io.plotting.data_residual_plot import ResidualPlot
 from threeML.plugin_prototype import PluginPrototype
@@ -30,7 +33,7 @@ if threeML_config.plotting.use_threeml_style:
 __instrument_name = "Fermi LAT (standard classes)"
 
 
-log = setup_logger(__name__)
+
 
 
 class MyPointSource(LikelihoodComponent.GenericSource):

--- a/threeML/plugins/FermipyLike.py
+++ b/threeML/plugins/FermipyLike.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import collections
 import os
@@ -29,7 +28,7 @@ from threeML.utils.statistics.gammaln import logfactorial
 from threeML.utils.statistics.stats_tools import Significance
 from threeML.utils.unique_deterministic_tag import get_unique_deterministic_tag
 
-
+log = logging.getLogger(__name__)
 
 __instrument_name = "Fermi LAT (with fermipy)"
 

--- a/threeML/plugins/FermipyLike.py
+++ b/threeML/plugins/FermipyLike.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import collections
 import os
 from typing import Any, Dict, List, Optional, Union
@@ -16,7 +19,7 @@ from threeML.config.plotting_structure import FermiSpectrumPlot
 from threeML.exceptions.custom_exceptions import custom_warnings
 from threeML.io.dict_with_pretty_print import DictWithPrettyPrint
 from threeML.io.file_utils import sanitize_filename
-from threeML.io.logging import setup_logger
+
 from threeML.io.package_data import get_path_of_data_file
 from threeML.io.plotting.cmap_cycle import cmap_intervals
 from threeML.io.plotting.data_residual_plot import ResidualPlot
@@ -26,7 +29,7 @@ from threeML.utils.statistics.gammaln import logfactorial
 from threeML.utils.statistics.stats_tools import Significance
 from threeML.utils.unique_deterministic_tag import get_unique_deterministic_tag
 
-log = setup_logger(__name__)
+
 
 __instrument_name = "Fermi LAT (with fermipy)"
 

--- a/threeML/plugins/OGIPLike.py
+++ b/threeML/plugins/OGIPLike.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 from pathlib import Path
 from typing import Optional, Union
@@ -15,7 +14,7 @@ from threeML.utils.spectrum.pha_spectrum import PHASpectrum
 
 __instrument_name = "All OGIP-compliant instruments"
 
-
+log = logging.getLogger(__name__)
 
 _valid_obs_types = (str, Path, PHASpectrum, PHAII)
 _valid_bkg_types = (str, Path, PHASpectrum, PHAII, SpectrumLike, XYLike)

--- a/threeML/plugins/OGIPLike.py
+++ b/threeML/plugins/OGIPLike.py
@@ -1,9 +1,12 @@
+import logging
+log = logging.getLogger(__name__)
+
 from pathlib import Path
 from typing import Optional, Union
 
 import pandas as pd
 
-from threeML.io.logging import setup_logger
+
 from threeML.plugins.DispersionSpectrumLike import DispersionSpectrumLike
 from threeML.plugins.SpectrumLike import SpectrumLike
 from threeML.plugins.XYLike import XYLike
@@ -12,7 +15,7 @@ from threeML.utils.spectrum.pha_spectrum import PHASpectrum
 
 __instrument_name = "All OGIP-compliant instruments"
 
-log = setup_logger(__name__)
+
 
 _valid_obs_types = (str, Path, PHASpectrum, PHAII)
 _valid_bkg_types = (str, Path, PHASpectrum, PHAII, SpectrumLike, XYLike)

--- a/threeML/plugins/PhotometryLike.py
+++ b/threeML/plugins/PhotometryLike.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import collections
 import copy
@@ -14,7 +13,7 @@ from threeML.io.plotting.data_residual_plot import ResidualPlot
 from threeML.plugins.XYLike import XYLike
 from threeML.utils.photometry import FilterSet, PhotometericObservation
 
-
+log = logging.getLogger(__name__)
 
 __instrument_name = "Generic photometric data"
 

--- a/threeML/plugins/PhotometryLike.py
+++ b/threeML/plugins/PhotometryLike.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import collections
 import copy
 from typing import Any, Dict, Optional, Union
@@ -6,12 +9,12 @@ import numpy as np
 from speclite.filters import FilterResponse, FilterSequence
 
 from threeML.config import threeML_config
-from threeML.io.logging import setup_logger
+
 from threeML.io.plotting.data_residual_plot import ResidualPlot
 from threeML.plugins.XYLike import XYLike
 from threeML.utils.photometry import FilterSet, PhotometericObservation
 
-log = setup_logger(__name__)
+
 
 __instrument_name = "Generic photometric data"
 

--- a/threeML/plugins/SpectrumLike.py
+++ b/threeML/plugins/SpectrumLike.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import collections
 import copy
 import types
@@ -17,7 +20,7 @@ from astromodels.functions.priors import Truncated_gaussian, Uniform_prior
 from threeML.config.config import threeML_config
 from threeML.config.plotting_structure import BinnedSpectrumPlot
 from threeML.exceptions.custom_exceptions import NegativeBackground
-from threeML.io.logging import setup_logger
+
 from threeML.io.package_data import get_path_of_data_file
 from threeML.io.plotting.data_residual_plot import ResidualPlot
 from threeML.io.plotting.light_curve_plots import (
@@ -42,7 +45,7 @@ if threeML_config.plotting.use_threeml_style:
 
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
-log = setup_logger(__name__)
+
 
 NO_REBIN = 1e-99
 

--- a/threeML/plugins/SpectrumLike.py
+++ b/threeML/plugins/SpectrumLike.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import collections
 import copy
@@ -45,7 +44,7 @@ if threeML_config.plotting.use_threeml_style:
 
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
-
+log = logging.getLogger(__name__)
 
 NO_REBIN = 1e-99
 

--- a/threeML/plugins/UnbinnedPoissonLike.py
+++ b/threeML/plugins/UnbinnedPoissonLike.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import types
 from collections.abc import Iterable
@@ -15,7 +14,7 @@ from threeML.plugin_prototype import PluginPrototype
 __instrument_name = "n.a."
 
 
-
+log = logging.getLogger(__name__)
 
 _tiny = np.float64(np.finfo(1.0).tiny)
 

--- a/threeML/plugins/UnbinnedPoissonLike.py
+++ b/threeML/plugins/UnbinnedPoissonLike.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import types
 from collections.abc import Iterable
 from typing import Optional, Tuple, Union
@@ -6,13 +9,13 @@ import astromodels
 import numba as nb
 import numpy as np
 
-from threeML.io.logging import setup_logger
+
 from threeML.plugin_prototype import PluginPrototype
 
 __instrument_name = "n.a."
 
 
-log = setup_logger(__name__)
+
 
 _tiny = np.float64(np.finfo(1.0).tiny)
 

--- a/threeML/plugins/UnresolvedExtendedXYLike.py
+++ b/threeML/plugins/UnresolvedExtendedXYLike.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -16,7 +15,7 @@ if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
 
-
+log = logging.getLogger(__name__)
 
 
 class UnresolvedExtendedXYLike(XYLike):

--- a/threeML/plugins/UnresolvedExtendedXYLike.py
+++ b/threeML/plugins/UnresolvedExtendedXYLike.py
@@ -1,8 +1,11 @@
+import logging
+log = logging.getLogger(__name__)
+
 import matplotlib.pyplot as plt
 import numpy as np
 
 from threeML.config import threeML_config
-from threeML.io.logging import setup_logger
+
 from threeML.io.package_data import get_path_of_data_file
 from threeML.plugins.XYLike import XYLike
 
@@ -13,7 +16,7 @@ if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
 
-log = setup_logger(__name__)
+
 
 
 class UnresolvedExtendedXYLike(XYLike):

--- a/threeML/plugins/XYLike.py
+++ b/threeML/plugins/XYLike.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import copy
 from typing import Optional
@@ -28,7 +27,7 @@ if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
 
-
+log = logging.getLogger(__name__)
 
 __instrument_name = "n.a."
 

--- a/threeML/plugins/XYLike.py
+++ b/threeML/plugins/XYLike.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import copy
 from typing import Optional
 
@@ -13,7 +16,7 @@ from threeML.classicMLE.goodness_of_fit import GoodnessOfFit
 from threeML.classicMLE.joint_likelihood import JointLikelihood
 from threeML.config import threeML_config
 from threeML.data_list import DataList
-from threeML.io.logging import setup_logger
+
 from threeML.io.package_data import get_path_of_data_file
 from threeML.plugin_prototype import PluginPrototype
 from threeML.utils.statistics.likelihood_functions import (
@@ -25,7 +28,7 @@ if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
 
-log = setup_logger(__name__)
+
 
 __instrument_name = "n.a."
 

--- a/threeML/test/test_FermiLATLike.py
+++ b/threeML/test/test_FermiLATLike.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import astropy.units as u
 import matplotlib.pyplot as plt
@@ -17,7 +16,7 @@ from threeML.utils.data_builders.fermi.lat_transient_builder import (
 )
 from threeML.utils.data_download.Fermi_LAT.download_LAT_data import LAT_dataset
 
-
+log = logging.getLogger(__name__)
 
 skip_if_internet_is_not_available = pytest.mark.skipif(
     not internet_connection_is_active(), reason="No active internet connection"

--- a/threeML/test/test_FermiLATLike.py
+++ b/threeML/test/test_FermiLATLike.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import astropy.units as u
 import matplotlib.pyplot as plt
 import pytest
@@ -6,7 +9,7 @@ from astromodels import Model, PointSource, Powerlaw
 from threeML import plot_spectra
 from threeML.classicMLE.joint_likelihood import JointLikelihood
 from threeML.data_list import DataList
-from threeML.io.logging import setup_logger
+
 from threeML.io.network import internet_connection_is_active
 from threeML.utils.data_builders.fermi.lat_transient_builder import (
     TransientLATDataBuilder,
@@ -14,7 +17,7 @@ from threeML.utils.data_builders.fermi.lat_transient_builder import (
 )
 from threeML.utils.data_download.Fermi_LAT.download_LAT_data import LAT_dataset
 
-log = setup_logger(__name__)
+
 
 skip_if_internet_is_not_available = pytest.mark.skipif(
     not internet_connection_is_active(), reason="No active internet connection"

--- a/threeML/test/test_FermipyLike.py
+++ b/threeML/test/test_FermipyLike.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import numpy as np
 import pytest
@@ -10,6 +9,8 @@ from threeML.classicMLE.joint_likelihood import JointLikelihood
 from threeML.data_list import DataList
 from threeML.io.network import internet_connection_is_active
 from threeML.utils.data_download.Fermi_LAT.download_LAT_data import download_LAT_data
+
+log = logging.getLogger(__name__)
 
 skip_if_internet_is_not_available = pytest.mark.skipif(
     not internet_connection_is_active(), reason="No active internet connection"

--- a/threeML/test/test_FermipyLike.py
+++ b/threeML/test/test_FermipyLike.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import numpy as np
 import pytest
 
@@ -5,12 +8,8 @@ from threeML import is_plugin_available
 from threeML.catalogs.FermiLAT import FermiLATSourceCatalog, FermiPySourceCatalog
 from threeML.classicMLE.joint_likelihood import JointLikelihood
 from threeML.data_list import DataList
-from threeML.io.logging import setup_logger, update_logging_level
 from threeML.io.network import internet_connection_is_active
 from threeML.utils.data_download.Fermi_LAT.download_LAT_data import download_LAT_data
-
-log = setup_logger(__name__)
-update_logging_level("INFO")
 
 skip_if_internet_is_not_available = pytest.mark.skipif(
     not internet_connection_is_active(), reason="No active internet connection"

--- a/threeML/test/test_configuration.py
+++ b/threeML/test/test_configuration.py
@@ -7,7 +7,7 @@ from omegaconf.errors import ReadonlyConfigError
 
 from threeML.config import get_current_configuration_copy, show_configuration
 from threeML.config.config_structure import Config
-from threeML.io.package_data import get_path_of_user_config
+from threeML.config.config import get_path_of_user_config
 
 
 def test_default_configuration():

--- a/threeML/test/test_model_from_catalog.py
+++ b/threeML/test/test_model_from_catalog.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import copy
 
 import astropy.units as u
@@ -15,11 +18,11 @@ from threeML import (
 )
 from threeML.utils.data_download.Fermi_LAT.download_LAT_data import download_LAT_data
 from threeML.catalogs.catalog_utils import _sanitize_fgl_name
-from threeML.io.logging import setup_logger
+
 from threeML.io.network import internet_connection_is_active
 from threeML.plugins.FermipyLike import FermipyLike
 
-log = setup_logger(__name__)
+
 
 skip_if_internet_is_not_available = pytest.mark.skipif(
     not internet_connection_is_active(), reason="No active internet connection"

--- a/threeML/test/test_model_from_catalog.py
+++ b/threeML/test/test_model_from_catalog.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import copy
 
@@ -22,7 +21,7 @@ from threeML.catalogs.catalog_utils import _sanitize_fgl_name
 from threeML.io.network import internet_connection_is_active
 from threeML.plugins.FermipyLike import FermipyLike
 
-
+log = logging.getLogger(__name__)
 
 skip_if_internet_is_not_available = pytest.mark.skipif(
     not internet_connection_is_active(), reason="No active internet connection"

--- a/threeML/test/test_verbosity.py
+++ b/threeML/test/test_verbosity.py
@@ -24,6 +24,9 @@ from threeML.io.logging import (
 )
 from threeML.utils.progress_bar import tqdm, trange
 
+from threeML.io.logging import add_startup_warning, log_threeml_startup_warnings
+
+logger = logging.getLogger(__name__)
 
 def test_all_toggles():
     toggle_progress_bars()
@@ -159,3 +162,14 @@ def test_logging_toggles():
     assert astromodels_console_log_handler.level == logging.DEBUG
 
     assert astromodels_usr_log_handler.level == logging.CRITICAL
+
+def test_startup_warnings(caplog):
+
+    msg = "TEST_STARTUP_WARNINGS"
+
+    add_startup_warning(logger, msg)
+
+    with caplog.at_level(logging.WARNING):
+        log_threeml_startup_warnings(logger)
+
+    assert msg in caplog.text

--- a/threeML/test/test_verbosity.py
+++ b/threeML/test/test_verbosity.py
@@ -24,9 +24,11 @@ from threeML.io.logging import (
 )
 from threeML.utils.progress_bar import tqdm, trange
 
-from threeML.io.logging import add_startup_warning, log_threeml_startup_warnings
+from threeML.io.logging import (add_startup_warning,
+                                log_threeml_startup_warnings,
+                                setup_logger)
 
-logger = logging.getLogger(__name__)
+logger = setup_logger(__name__)
 
 
 def test_all_toggles():

--- a/threeML/test/test_verbosity.py
+++ b/threeML/test/test_verbosity.py
@@ -28,6 +28,7 @@ from threeML.io.logging import add_startup_warning, log_threeml_startup_warnings
 
 logger = logging.getLogger(__name__)
 
+
 def test_all_toggles():
     toggle_progress_bars()
 
@@ -162,6 +163,7 @@ def test_logging_toggles():
     assert astromodels_console_log_handler.level == logging.DEBUG
 
     assert astromodels_usr_log_handler.level == logging.CRITICAL
+
 
 def test_startup_warnings(caplog):
 

--- a/threeML/utils/OGIP/pha.py
+++ b/threeML/utils/OGIP/pha.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 from pathlib import Path
 from typing import Optional
 
@@ -7,10 +10,10 @@ import numpy as np
 
 from threeML.io.file_utils import sanitize_filename
 from threeML.io.fits_file import FITSExtension, FITSFile
-from threeML.io.logging import setup_logger
+
 from threeML.utils.OGIP.response import EBOUNDS, SPECRESP_MATRIX
 
-log = setup_logger(__name__)
+
 
 
 class PHAWrite:

--- a/threeML/utils/OGIP/pha.py
+++ b/threeML/utils/OGIP/pha.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 from pathlib import Path
 from typing import Optional
@@ -13,7 +12,7 @@ from threeML.io.fits_file import FITSExtension, FITSFile
 
 from threeML.utils.OGIP.response import EBOUNDS, SPECRESP_MATRIX
 
-
+log = logging.getLogger(__name__)
 
 
 class PHAWrite:

--- a/threeML/utils/OGIP/response.py
+++ b/threeML/utils/OGIP/response.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import copy
 from collections.abc import Callable
@@ -29,7 +28,7 @@ from threeML.utils.time_interval import TimeInterval, TimeIntervalSet
 if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
-
+log = logging.getLogger(__name__)
 
 
 class NoCoverageIntervals(RuntimeError):

--- a/threeML/utils/OGIP/response.py
+++ b/threeML/utils/OGIP/response.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import copy
 from collections.abc import Callable
 from operator import attrgetter, itemgetter
@@ -19,14 +22,14 @@ from threeML.io.file_utils import (
     sanitize_filename,
 )
 from threeML.io.fits_file import FITSExtension, FITSFile
-from threeML.io.logging import setup_logger
+
 from threeML.io.package_data import get_path_of_data_file
 from threeML.utils.time_interval import TimeInterval, TimeIntervalSet
 
 if threeML_config.plotting.use_threeml_style:
     plt.style.use(str(get_path_of_data_file("threeml.mplstyle")))
 
-log = setup_logger(__name__)
+
 
 
 class NoCoverageIntervals(RuntimeError):

--- a/threeML/utils/bayesian_blocks.py
+++ b/threeML/utils/bayesian_blocks.py
@@ -1,7 +1,6 @@
 # Author: Giacomo Vianello (giacomov@stanford.edu)
 
 import logging
-logger = logging.getLogger(__name__)
 
 import sys
 
@@ -10,6 +9,8 @@ import numpy as np
 
 
 from threeML.utils.progress_bar import tqdm
+
+logger = logging.getLogger(__name__)
 
 __all__ = ["bayesian_blocks", "bayesian_blocks_not_unique"]
 

--- a/threeML/utils/bayesian_blocks.py
+++ b/threeML/utils/bayesian_blocks.py
@@ -1,15 +1,15 @@
 # Author: Giacomo Vianello (giacomov@stanford.edu)
 
+import logging
+logger = logging.getLogger(__name__)
 
 import sys
 
 import numexpr
 import numpy as np
 
-from threeML.io.logging import setup_logger
-from threeML.utils.progress_bar import tqdm
 
-logger = setup_logger(__name__)
+from threeML.utils.progress_bar import tqdm
 
 __all__ = ["bayesian_blocks", "bayesian_blocks_not_unique"]
 

--- a/threeML/utils/binner.py
+++ b/threeML/utils/binner.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import numba as nb
 import numpy as np
@@ -12,7 +11,7 @@ from threeML.utils.progress_bar import tqdm
 from threeML.utils.statistics.stats_tools import Significance
 from threeML.utils.time_interval import TimeIntervalSet
 
-
+log = logging.getLogger(__name__)
 
 
 class NotEnoughData(RuntimeError):

--- a/threeML/utils/binner.py
+++ b/threeML/utils/binner.py
@@ -1,15 +1,18 @@
+import logging
+log = logging.getLogger(__name__)
+
 import numba as nb
 import numpy as np
 
 from threeML.config.config import threeML_config
-from threeML.io.logging import setup_logger
+
 from threeML.utils.bayesian_blocks import bayesian_blocks, bayesian_blocks_not_unique
 from threeML.utils.numba_utils import VectorFloat64, VectorInt64
 from threeML.utils.progress_bar import tqdm
 from threeML.utils.statistics.stats_tools import Significance
 from threeML.utils.time_interval import TimeIntervalSet
 
-log = setup_logger(__name__)
+
 
 
 class NotEnoughData(RuntimeError):

--- a/threeML/utils/data_builders/fermi/gbm_data.py
+++ b/threeML/utils/data_builders/fermi/gbm_data.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import collections
 import re
 
@@ -6,13 +9,13 @@ import numpy as np
 import pandas as pd
 import requests
 
-from threeML.io.logging import setup_logger
+
 from threeML.utils.fermi_relative_mission_time import (
     compute_fermi_relative_mission_times,
 )
 from threeML.utils.spectrum.pha_spectrum import PHASpectrumSet
 
-log = setup_logger(__name__)
+
 
 
 class GBMTTEFile(object):

--- a/threeML/utils/data_builders/fermi/gbm_data.py
+++ b/threeML/utils/data_builders/fermi/gbm_data.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import collections
 import re
@@ -15,7 +14,7 @@ from threeML.utils.fermi_relative_mission_time import (
 )
 from threeML.utils.spectrum.pha_spectrum import PHASpectrumSet
 
-
+log = logging.getLogger(__name__)
 
 
 class GBMTTEFile(object):

--- a/threeML/utils/data_builders/fermi/lat_data.py
+++ b/threeML/utils/data_builders/fermi/lat_data.py
@@ -1,15 +1,18 @@
+import logging
+log = logging.getLogger(__name__)
+
 import collections
 
 import astropy.io.fits as fits
 import numpy as np
 import pandas as pd
 
-from threeML.io.logging import setup_logger
+
 from threeML.utils.fermi_relative_mission_time import (
     compute_fermi_relative_mission_times,
 )
 
-log = setup_logger(__name__)
+
 
 
 class LLEFile(object):

--- a/threeML/utils/data_builders/fermi/lat_data.py
+++ b/threeML/utils/data_builders/fermi/lat_data.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import collections
 
@@ -12,7 +11,7 @@ from threeML.utils.fermi_relative_mission_time import (
     compute_fermi_relative_mission_times,
 )
 
-
+log = logging.getLogger(__name__)
 
 
 class LLEFile(object):

--- a/threeML/utils/data_builders/fermi/lat_transient_builder.py
+++ b/threeML/utils/data_builders/fermi/lat_transient_builder.py
@@ -12,7 +12,6 @@ from glob import glob
 import pandas as pd
 import yaml
 
-from threeML.config import threeML_config
 from threeML.io.file_utils import file_existing_and_readable
 from threeML.io.logging import add_startup_warning
 
@@ -43,6 +42,7 @@ except Exception as e:
     spectra = None
 
     add_startup_warning(log, "No fermitools installed")
+
 
 class LATLikelihoodParameter(object):
     def __init__(

--- a/threeML/utils/data_builders/fermi/lat_transient_builder.py
+++ b/threeML/utils/data_builders/fermi/lat_transient_builder.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import collections
 import os
@@ -19,7 +18,7 @@ from threeML.io.file_utils import file_existing_and_readable
 
 pd.reset_option("display.float_format")
 
-
+log = logging.getLogger(__name__)
 
 try:
     from GtBurst import IRFS

--- a/threeML/utils/data_builders/fermi/lat_transient_builder.py
+++ b/threeML/utils/data_builders/fermi/lat_transient_builder.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import collections
 import os
 import re
@@ -12,11 +15,11 @@ import yaml
 
 from threeML.config import threeML_config
 from threeML.io.file_utils import file_existing_and_readable
-from threeML.io.logging import setup_logger
+
 
 pd.reset_option("display.float_format")
 
-log = setup_logger(__name__)
+
 
 try:
     from GtBurst import IRFS

--- a/threeML/utils/data_builders/fermi/lat_transient_builder.py
+++ b/threeML/utils/data_builders/fermi/lat_transient_builder.py
@@ -14,7 +14,7 @@ import yaml
 
 from threeML.config import threeML_config
 from threeML.io.file_utils import file_existing_and_readable
-
+from threeML.io.logging import add_startup_warning
 
 pd.reset_option("display.float_format")
 
@@ -42,9 +42,7 @@ except Exception as e:
     irfs = None
     spectra = None
 
-    if threeML_config.logging.startup_warnings:
-        log.warning("No fermitools installed")
-
+    add_startup_warning(log, "No fermitools installed")
 
 class LATLikelihoodParameter(object):
     def __init__(

--- a/threeML/utils/data_builders/time_series_builder.py
+++ b/threeML/utils/data_builders/time_series_builder.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import copy
 import re
@@ -42,7 +41,7 @@ from threeML.utils.time_series.event_list import (
 )
 from threeML.utils.time_series.time_series import TimeSeries
 
-
+log = logging.getLogger(__name__)
 
 try:
     from polarpy.polar_data import POLARData

--- a/threeML/utils/data_builders/time_series_builder.py
+++ b/threeML/utils/data_builders/time_series_builder.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import copy
 import re
 from pathlib import Path
@@ -9,7 +12,7 @@ import numpy as np
 from threeML.config.config import threeML_config
 from threeML.config.config_utils import get_value_kwargs
 from threeML.io.file_utils import file_existing_and_readable, sanitize_filename
-from threeML.io.logging import setup_logger, silence_console_log
+from threeML.io.logging import silence_console_log
 from threeML.plugins.DispersionSpectrumLike import DispersionSpectrumLike
 from threeML.plugins.OGIPLike import OGIPLike
 from threeML.plugins.SpectrumLike import NegativeBackground, SpectrumLike
@@ -39,7 +42,7 @@ from threeML.utils.time_series.event_list import (
 )
 from threeML.utils.time_series.time_series import TimeSeries
 
-log = setup_logger(__name__)
+
 
 try:
     from polarpy.polar_data import POLARData
@@ -387,7 +390,7 @@ class TimeSeriesBuilder(object):
 
         file_name: Path = sanitize_filename(file_name)
 
-        with silence_console_log(and_progress_bars=False):
+        with silence_console_log(log, and_progress_bars=False):
             ogip_list = [
                 OGIPLike.from_general_dispersion_spectrum(sl)
                 for sl in self.to_spectrumlike(
@@ -762,7 +765,7 @@ class TimeSeriesBuilder(object):
 
             # loop through the intervals and create spec likes
 
-            with silence_console_log(and_progress_bars=False):
+            with silence_console_log(log, and_progress_bars=False):
                 for i, interval in enumerate(tqdm(these_bins, desc="Creating plugins")):
                     self.set_active_time_interval(interval.to_string())
 

--- a/threeML/utils/data_download/Fermi_GBM/download_GBM_data.py
+++ b/threeML/utils/data_download/Fermi_GBM/download_GBM_data.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import os
 import re
@@ -20,7 +19,7 @@ from threeML.io.file_utils import (
 )
 
 
-
+log = logging.getLogger(__name__)
 
 
 def _validate_fermi_date(year: str, month: str, day: str) -> str:

--- a/threeML/utils/data_download/Fermi_GBM/download_GBM_data.py
+++ b/threeML/utils/data_download/Fermi_GBM/download_GBM_data.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import os
 import re
 from builtins import map
@@ -15,9 +18,9 @@ from threeML.io.file_utils import (
     if_directory_not_existing_then_make,
     sanitize_filename,
 )
-from threeML.io.logging import setup_logger
 
-log = setup_logger(__name__)
+
+
 
 
 def _validate_fermi_date(year: str, month: str, day: str) -> str:

--- a/threeML/utils/data_download/Fermi_LAT/download_LAT_data.py
+++ b/threeML/utils/data_download/Fermi_LAT/download_LAT_data.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import html.parser
 import os
@@ -21,7 +20,7 @@ from threeML.io.file_utils import sanitize_filename
 
 from threeML.utils.unique_deterministic_tag import get_unique_deterministic_tag
 
-
+log = logging.getLogger(__name__)
 
 # Set default timeout for operations
 socket.setdefaulttimeout(180)

--- a/threeML/utils/data_download/Fermi_LAT/download_LAT_data.py
+++ b/threeML/utils/data_download/Fermi_LAT/download_LAT_data.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 import html.parser
 import os
 import re
@@ -15,10 +18,10 @@ from threeML.config.config import threeML_config
 from threeML.exceptions.custom_exceptions import TimeTypeNotKnown
 from threeML.io.download_from_http import ApacheDirectory
 from threeML.io.file_utils import sanitize_filename
-from threeML.io.logging import setup_logger
+
 from threeML.utils.unique_deterministic_tag import get_unique_deterministic_tag
 
-log = setup_logger(__name__)
+
 
 # Set default timeout for operations
 socket.setdefaulttimeout(180)

--- a/threeML/utils/fitted_objects/fitted_point_sources.py
+++ b/threeML/utils/fitted_objects/fitted_point_sources.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 __author__ = "grburgess"
 
 import collections
@@ -10,12 +13,12 @@ from astropy import units as u
 
 from threeML.config import threeML_config
 from threeML.config.point_source_structure import IntegrateMethod
-from threeML.io.logging import setup_logger
+
 from threeML.utils.fitted_objects.fitted_source_handler import (
     GenericFittedSourceHandler,
 )
 
-log = setup_logger(__name__)
+
 
 np_version = Version(np.__version__)
 if np_version < Version("2.0.0"):

--- a/threeML/utils/fitted_objects/fitted_point_sources.py
+++ b/threeML/utils/fitted_objects/fitted_point_sources.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 __author__ = "grburgess"
 
@@ -18,7 +17,7 @@ from threeML.utils.fitted_objects.fitted_source_handler import (
     GenericFittedSourceHandler,
 )
 
-
+log = logging.getLogger(__name__)
 
 np_version = Version(np.__version__)
 if np_version < Version("2.0.0"):

--- a/threeML/utils/fitted_objects/fitted_source_handler.py
+++ b/threeML/utils/fitted_objects/fitted_source_handler.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 __author__ = "grburgess"
 
 import functools
@@ -8,11 +11,11 @@ from astromodels import use_astromodels_memoization
 from joblib import Parallel, delayed
 
 from threeML.config import threeML_config
-from threeML.io.logging import setup_logger
+
 from threeML.parallel.parallel_client import ParallelClient
 from threeML.utils.progress_bar import tqdm
 
-log = setup_logger(__name__)
+
 
 
 class GenericFittedSourceHandler(object):

--- a/threeML/utils/fitted_objects/fitted_source_handler.py
+++ b/threeML/utils/fitted_objects/fitted_source_handler.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 __author__ = "grburgess"
 
@@ -15,7 +14,7 @@ from threeML.config import threeML_config
 from threeML.parallel.parallel_client import ParallelClient
 from threeML.utils.progress_bar import tqdm
 
-
+log = logging.getLogger(__name__)
 
 
 class GenericFittedSourceHandler(object):

--- a/threeML/utils/interval.py
+++ b/threeML/utils/interval.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import copy
 import re
@@ -9,7 +8,7 @@ import numpy as np
 
 
 
-
+log = logging.getLogger(__name__)
 
 
 class IntervalsDoNotOverlap(RuntimeError):

--- a/threeML/utils/interval.py
+++ b/threeML/utils/interval.py
@@ -1,12 +1,15 @@
+import logging
+log = logging.getLogger(__name__)
+
 import copy
 import re
 from operator import attrgetter, itemgetter
 
 import numpy as np
 
-from threeML.io.logging import setup_logger
 
-log = setup_logger(__name__)
+
+
 
 
 class IntervalsDoNotOverlap(RuntimeError):

--- a/threeML/utils/interval.py
+++ b/threeML/utils/interval.py
@@ -6,8 +6,6 @@ from operator import attrgetter, itemgetter
 
 import numpy as np
 
-
-
 log = logging.getLogger(__name__)
 
 

--- a/threeML/utils/photometry/filter_library.py
+++ b/threeML/utils/photometry/filter_library.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 from pathlib import Path
 
 import astropy.units as u
@@ -5,11 +8,11 @@ import h5py
 import speclite.filters as spec_filter
 import yaml
 
-from threeML.io.logging import setup_logger
+
 from threeML.io.package_data import get_path_of_data_dir
 from threeML.utils.progress_bar import tqdm
 
-log = setup_logger(__name__)
+
 
 
 def get_speclite_filter_path() -> Path:

--- a/threeML/utils/photometry/filter_library.py
+++ b/threeML/utils/photometry/filter_library.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 from pathlib import Path
 
@@ -12,7 +11,7 @@ import yaml
 from threeML.io.package_data import get_path_of_data_dir
 from threeML.utils.progress_bar import tqdm
 
-
+log = logging.getLogger(__name__)
 
 
 def get_speclite_filter_path() -> Path:

--- a/threeML/utils/spectrum/binned_spectrum.py
+++ b/threeML/utils/spectrum/binned_spectrum.py
@@ -1,15 +1,18 @@
+import logging
+log = logging.getLogger(__name__)
+
 from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
 
-from threeML.io.logging import setup_logger
+
 from threeML.utils.histogram import Histogram
 from threeML.utils.interval import Interval, IntervalSet
 from threeML.utils.OGIP.response import InstrumentResponse
 from threeML.utils.statistics.stats_tools import sqrt_sum_of_squares
 
-log = setup_logger(__name__)
+
 
 
 class Channel(Interval):

--- a/threeML/utils/spectrum/binned_spectrum.py
+++ b/threeML/utils/spectrum/binned_spectrum.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 from typing import Optional, Union
 
@@ -12,7 +11,7 @@ from threeML.utils.interval import Interval, IntervalSet
 from threeML.utils.OGIP.response import InstrumentResponse
 from threeML.utils.statistics.stats_tools import sqrt_sum_of_squares
 
-
+log = logging.getLogger(__name__)
 
 
 class Channel(Interval):

--- a/threeML/utils/spectrum/pha_spectrum.py
+++ b/threeML/utils/spectrum/pha_spectrum.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -20,7 +19,7 @@ from threeML.utils.spectrum.binned_spectrum import (
 from threeML.utils.spectrum.binned_spectrum_set import BinnedSpectrumSet
 from threeML.utils.time_interval import TimeIntervalSet
 
-
+log = logging.getLogger(__name__)
 
 _required_keywords = {}
 _required_keywords["observed"] = (

--- a/threeML/utils/spectrum/pha_spectrum.py
+++ b/threeML/utils/spectrum/pha_spectrum.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, Union
@@ -6,7 +9,7 @@ import astropy.io.fits as fits
 import numpy as np
 
 from threeML.io.fits_file import FITSFile
-from threeML.io.logging import setup_logger
+
 from threeML.utils.OGIP.pha import PHAII
 from threeML.utils.OGIP.response import InstrumentResponse, OGIPResponse
 from threeML.utils.progress_bar import trange
@@ -17,7 +20,7 @@ from threeML.utils.spectrum.binned_spectrum import (
 from threeML.utils.spectrum.binned_spectrum_set import BinnedSpectrumSet
 from threeML.utils.time_interval import TimeIntervalSet
 
-log = setup_logger(__name__)
+
 
 _required_keywords = {}
 _required_keywords["observed"] = (

--- a/threeML/utils/spectrum/share_spectrum.py
+++ b/threeML/utils/spectrum/share_spectrum.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import numpy as np
 
@@ -7,7 +6,7 @@ import numpy as np
 from threeML.plugins.DispersionSpectrumLike import DispersionSpectrumLike
 from threeML.plugins.SpectrumLike import SpectrumLike
 
-
+log = logging.getLogger(__name__)
 
 
 class ShareSpectrum(object):

--- a/threeML/utils/spectrum/share_spectrum.py
+++ b/threeML/utils/spectrum/share_spectrum.py
@@ -1,10 +1,13 @@
+import logging
+log = logging.getLogger(__name__)
+
 import numpy as np
 
-from threeML.io.logging import setup_logger
+
 from threeML.plugins.DispersionSpectrumLike import DispersionSpectrumLike
 from threeML.plugins.SpectrumLike import SpectrumLike
 
-log = setup_logger(__name__)
+
 
 
 class ShareSpectrum(object):

--- a/threeML/utils/spectrum/spectrum_likelihood.py
+++ b/threeML/utils/spectrum/spectrum_likelihood.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 import copy
 from builtins import object
@@ -16,7 +15,7 @@ from threeML.utils.statistics.likelihood_functions import (
     poisson_observed_poisson_background,
 )
 
-
+log = logging.getLogger(__name__)
 
 # These classes provide likelihood evaluation to SpectrumLike and children
 

--- a/threeML/utils/spectrum/spectrum_likelihood.py
+++ b/threeML/utils/spectrum/spectrum_likelihood.py
@@ -1,10 +1,13 @@
+import logging
+log = logging.getLogger(__name__)
+
 import copy
 from builtins import object
 from typing import Optional
 
 import numpy as np
 
-from threeML.io.logging import setup_logger
+
 from threeML.utils.numba_utils import nb_sum
 from threeML.utils.statistics.likelihood_functions import (
     half_chi2,
@@ -13,7 +16,7 @@ from threeML.utils.statistics.likelihood_functions import (
     poisson_observed_poisson_background,
 )
 
-log = setup_logger(__name__)
+
 
 # These classes provide likelihood evaluation to SpectrumLike and children
 

--- a/threeML/utils/statistics/stats_tools.py
+++ b/threeML/utils/statistics/stats_tools.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 from math import sqrt
 
 import numpy as np
@@ -5,12 +8,12 @@ import scipy.interpolate
 import scipy.stats
 from scipy.special import erfinv
 
-from threeML.io.logging import setup_logger
+
 
 # Provides some universal statistical utilities and stats comparison tools
 
 
-log = setup_logger(__name__)
+
 
 
 def aic(log_like, n_parameters, n_data_points):

--- a/threeML/utils/statistics/stats_tools.py
+++ b/threeML/utils/statistics/stats_tools.py
@@ -7,12 +7,9 @@ import scipy.interpolate
 import scipy.stats
 from scipy.special import erfinv
 
-
+log = logging.getLogger(__name__)
 
 # Provides some universal statistical utilities and stats comparison tools
-
-
-log = logging.getLogger(__name__)
 
 
 def aic(log_like, n_parameters, n_data_points):

--- a/threeML/utils/statistics/stats_tools.py
+++ b/threeML/utils/statistics/stats_tools.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 from math import sqrt
 
@@ -13,7 +12,7 @@ from scipy.special import erfinv
 # Provides some universal statistical utilities and stats comparison tools
 
 
-
+log = logging.getLogger(__name__)
 
 
 def aic(log_like, n_parameters, n_data_points):

--- a/threeML/utils/time_series/binned_spectrum_series.py
+++ b/threeML/utils/time_series/binned_spectrum_series.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 from builtins import range, zip
 
@@ -15,7 +14,7 @@ from threeML.utils.time_interval import TimeIntervalSet
 from threeML.utils.time_series.polynomial import polyfit
 from threeML.utils.time_series.time_series import TimeSeries
 
-
+log = logging.getLogger(__name__)
 
 
 class BinnedSpectrumSeries(TimeSeries):

--- a/threeML/utils/time_series/binned_spectrum_series.py
+++ b/threeML/utils/time_series/binned_spectrum_series.py
@@ -1,10 +1,13 @@
+import logging
+log = logging.getLogger(__name__)
+
 from builtins import range, zip
 
 import matplotlib.pyplot as plt
 import numpy as np
 
 from threeML.config.config import threeML_config
-from threeML.io.logging import setup_logger, silence_console_log
+from threeML.io.logging import silence_console_log
 from threeML.io.plotting.light_curve_plots import binned_light_curve_plot
 from threeML.parallel.parallel_client import ParallelClient
 from threeML.utils.progress_bar import tqdm
@@ -12,7 +15,7 @@ from threeML.utils.time_interval import TimeIntervalSet
 from threeML.utils.time_series.polynomial import polyfit
 from threeML.utils.time_series.time_series import TimeSeries
 
-log = setup_logger(__name__)
+
 
 
 class BinnedSpectrumSeries(TimeSeries):
@@ -363,7 +366,7 @@ class BinnedSpectrumSeries(TimeSeries):
         if threeML_config["parallel"]["use_parallel"]:
 
             def worker(counts):
-                with silence_console_log():
+                with silence_console_log(log):
                     polynomial, _ = polyfit(
                         selected_midpoints,
                         counts,
@@ -389,7 +392,7 @@ class BinnedSpectrumSeries(TimeSeries):
             for counts in tqdm(
                 selected_counts.T, desc=f"Fitting {self._instrument} background"
             ):
-                with silence_console_log():
+                with silence_console_log(log):
                     polynomial, _ = polyfit(
                         selected_midpoints,
                         counts,

--- a/threeML/utils/time_series/event_list.py
+++ b/threeML/utils/time_series/event_list.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 from builtins import range, zip
 
 __author__ = "grburgess"
@@ -8,7 +11,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from threeML.config.config import threeML_config
-from threeML.io.logging import setup_logger
+
 from threeML.io.plotting.light_curve_plots import binned_light_curve_plot
 from threeML.parallel.parallel_client import ParallelClient
 from threeML.utils.binner import TemporalBinner
@@ -17,7 +20,7 @@ from threeML.utils.time_interval import TimeIntervalSet
 from threeML.utils.time_series.polynomial import polyfit, unbinned_polyfit
 from threeML.utils.time_series.time_series import TimeSeries
 
-log = setup_logger(__name__)
+
 
 
 class ReducingNumberOfThreads(Warning):

--- a/threeML/utils/time_series/event_list.py
+++ b/threeML/utils/time_series/event_list.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 from builtins import range, zip
 
@@ -20,7 +19,7 @@ from threeML.utils.time_interval import TimeIntervalSet
 from threeML.utils.time_series.polynomial import polyfit, unbinned_polyfit
 from threeML.utils.time_series.time_series import TimeSeries
 
-
+log = logging.getLogger(__name__)
 
 
 class ReducingNumberOfThreads(Warning):

--- a/threeML/utils/time_series/polynomial.py
+++ b/threeML/utils/time_series/polynomial.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 from typing import Iterable, Optional, Tuple
 
 import numpy as np
@@ -18,7 +21,7 @@ from threeML.config.config import threeML_config
 from threeML.config.config_utils import get_value
 from threeML.data_list import DataList
 from threeML.exceptions.custom_exceptions import BadCovariance  # , FitFailed
-from threeML.io.logging import setup_logger, silence_console_log
+from threeML.io.logging import silence_console_log
 from threeML.minimizer.grid_minimizer import AllFitFailed
 from threeML.minimizer.minimization import (
     CannotComputeCovariance,
@@ -29,7 +32,7 @@ from threeML.minimizer.minimization import (
 from threeML.plugins.UnbinnedPoissonLike import EventObservation, UnbinnedPoissonLike
 from threeML.plugins.XYLike import XYLike
 
-log = setup_logger(__name__)
+
 
 # we include the line twice to mimic a constant
 _grade_model_lookup = (Line, Line, Quadratic, Cubic, Quartic)
@@ -214,7 +217,7 @@ def polyfit(
 
     log.debug(f"starting polyfit with avg norm {avg}")
 
-    with silence_console_log():
+    with silence_console_log(log):
         xy = XYLike(
             "series", x=x, y=y, exposure=exposure, poisson_data=True, quiet=True
         )
@@ -374,7 +377,7 @@ def unbinned_polyfit(
 
     shape = _grade_model_lookup[grade]()
 
-    with silence_console_log():
+    with silence_console_log(log):
         ps = PointSource("dummy", 0, 0, spectral_shape=shape)
 
         model = Model(ps)

--- a/threeML/utils/time_series/polynomial.py
+++ b/threeML/utils/time_series/polynomial.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 from typing import Iterable, Optional, Tuple
 
@@ -32,7 +31,7 @@ from threeML.minimizer.minimization import (
 from threeML.plugins.UnbinnedPoissonLike import EventObservation, UnbinnedPoissonLike
 from threeML.plugins.XYLike import XYLike
 
-
+log = logging.getLogger(__name__)
 
 # we include the line twice to mimic a constant
 _grade_model_lookup = (Line, Line, Quadratic, Cubic, Quartic)

--- a/threeML/utils/time_series/time_series.py
+++ b/threeML/utils/time_series/time_series.py
@@ -1,5 +1,4 @@
 import logging
-log = logging.getLogger(__name__)
 
 __author__ = "grburgess"
 
@@ -24,7 +23,7 @@ from threeML.utils.spectrum.binned_spectrum import Quality
 from threeML.utils.time_interval import TimeIntervalSet
 from threeML.utils.time_series.polynomial import Polynomial, polyfit, unbinned_polyfit
 
-
+log = logging.getLogger(__name__)
 
 
 class ReducingNumberOfThreads(Warning):

--- a/threeML/utils/time_series/time_series.py
+++ b/threeML/utils/time_series/time_series.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 __author__ = "grburgess"
 
 import collections
@@ -14,14 +17,14 @@ import pandas as pd
 from threeML.config.config import threeML_config
 from threeML.config.config_utils import get_value_kwargs
 from threeML.io.file_utils import sanitize_filename
-from threeML.io.logging import setup_logger
+
 from threeML.parallel.parallel_client import ParallelClient
 from threeML.utils.progress_bar import trange
 from threeML.utils.spectrum.binned_spectrum import Quality
 from threeML.utils.time_interval import TimeIntervalSet
 from threeML.utils.time_series.polynomial import Polynomial, polyfit, unbinned_polyfit
 
-log = setup_logger(__name__)
+
 
 
 class ReducingNumberOfThreads(Warning):


### PR DESCRIPTION
This PR addresses #647

The philosophy is that 3ML is a library, which can be imported by larger libraries or by other application. As such, it should not handle it's own logs, only produce them and delegate the logging parent logging.

The main change is to follow best practices and have a `logging.getLogger(__name__)` at the beginning of each file instead of 3Ml customs `setup_logger`. 

The customization of the logger should only be done `__main__` so it can propagate to the loggers of all libraries. If the user want to recover the previous logging behavior (e.g. formatting, time rotatin file handlers) they can achieve this by explicitly calling 3ML's `setup_logger` in their `__main__`. Example: https://gist.github.com/israelmcmc/6bebe314b9d7bddcf6fecc0240926f96

In order to allow the user to decide how the startup_warning are formatting and where they go, there's now a function called `log_threeml_startup_warnings` (and `log_threeml_startup_warnings` from astromodels), that accepts the logger that will handle these logs. This was necessary because otherwise they would be printed during the initial import, before we could even call `setup_logger`. However, this also removed the need of a config file to prevent these warning, which is a plus imho. 

Lastly, I also moved `get_path_of_user_config` to fix a previously hidden circular import (the config needed the logging to log, and the logging module needed the config module to know what to do log!).

Astromodels companion: https://github.com/threeML/astromodels/pull/260