### PR TITLE
[FEAT]: More logging info discarded samples

### DIFF
--- a/threeML/analysis_results.py
+++ b/threeML/analysis_results.py
@@ -5,11 +5,11 @@ import inspect
 import logging
 import math
 import os
-from builtins import map, object, range, str
+import warnings
+from builtins import map, range, str
 from importlib.util import find_spec
 from pathlib import Path
 from typing import Dict, List, Optional
-import warnings
 
 import astromodels
 import astropy.units as u
@@ -101,13 +101,13 @@ class SEQUENCE(FITSExtension):
     def __init__(self, name, data_tuple):
         # Init FITS extension
 
-        super(SEQUENCE, self).__init__(data_tuple, self._HEADER_KEYWORDS)
+        super().__init__(data_tuple, self._HEADER_KEYWORDS)
 
         # Update keywords
         self.hdu.header.set("SEQ_TYPE", name)
 
 
-class ANALYSIS_RESULTS_HDF(object):
+class ANALYSIS_RESULTS_HDF:
     def __init__(self, analysis_results, hdf_obj):
         optimized_model = analysis_results.optimized_model
 
@@ -384,7 +384,7 @@ class ANALYSIS_RESULTS(FITSExtension):
 
         # Init FITS extension
 
-        super(ANALYSIS_RESULTS, self).__init__(data_tuple, self._HEADER_KEYWORDS)
+        super().__init__(data_tuple, self._HEADER_KEYWORDS)
 
         # Update keywords with their values for this instance
         self.hdu.header.set("MODEL", yaml_model_serialization)
@@ -447,7 +447,7 @@ class AnalysisResultsFITS(FITSFile):
         extensions.extend(results_ext)
 
         # Create FITS file
-        super(AnalysisResultsFITS, self).__init__(fits_extensions=extensions)
+        super().__init__(fits_extensions=extensions)
 
         # Set a couple of keywords in the primary header
         self._hdu_list[0].header.set("DATE", datetime.datetime.now().isoformat())
@@ -458,7 +458,7 @@ class AnalysisResultsFITS(FITSFile):
         )
 
 
-class _AnalysisResults(object):
+class _AnalysisResults:
     """A unified class to store results from a maximum likelihood or a Bayesian
     analysis, which provides a unique interface and allows for "error
     propagation" (which means different things in the two contexts) in
@@ -952,7 +952,7 @@ class BayesianResults(_AnalysisResults):
         statistical_measures,
         log_probabilty,
     ):
-        super(BayesianResults, self).__init__(
+        super().__init__(
             optimized_model,
             samples,
             posterior_values,
@@ -1186,7 +1186,7 @@ class BayesianResults(_AnalysisResults):
             i,
             val,
         ) in enumerate(labels):
-            if "$" not in labels[i]:
+            if "$" not in val:
                 labels[i] = val.replace("_", "")
 
         samples = self._samples_transposed.T
@@ -1310,7 +1310,7 @@ class BayesianResults(_AnalysisResults):
                 i,
                 val,
             ) in enumerate(labels_other):
-                if "$" not in labels_other[i]:
+                if "$" not in val:
                     labels_other[i] = val.replace("_", " ")
 
             if names is not None:
@@ -1345,7 +1345,7 @@ class BayesianResults(_AnalysisResults):
             i,
             val,
         ) in enumerate(labels):
-            if "$" not in labels[i]:
+            if "$" not in val:
                 labels[i] = val.replace("_", " ")
 
         if names is not None:
@@ -1667,12 +1667,12 @@ class MLEResults(_AnalysisResults):
             )
             warnings.warn(
                 UserWarning(
-                    f"{n_removed_samples / samples.shape[0] * 100.0:.1f}% of samples have "
-                    "been thrown away because they failed the constraints on the "
-                    "parameters. This result might not be suitable for error propagation. "
-                    "Enlarge the boundaries until you lose less than 1% of the samples.\n"
-                    f"Discarded samples in excluded parameter space ({n_removed_samples} "
-                    f"samples):\n{summary}"
+                    f"{n_removed_samples / samples.shape[0] * 100.0:.1f}% of samples "
+                    "have been thrown away because they failed the constraints on the "
+                    "parameters. This result might not be suitable for error "
+                    "propagation. Enlarge the boundaries until you lose less than 1% of"
+                    "the samples.\nDiscarded samples in excluded parameter space "
+                    f"({n_removed_samples} samples):\n{summary}"
                 )
             )
 
@@ -1684,7 +1684,7 @@ class MLEResults(_AnalysisResults):
                 samples[:, i] = parameter.transformation.backward(samples[:, i])
         # Finally build the class
 
-        super(MLEResults, self).__init__(
+        super().__init__(
             optimized_model,
             samples,
             likelihood_values,

--- a/threeML/analysis_results.py
+++ b/threeML/analysis_results.py
@@ -9,6 +9,7 @@ from builtins import map, object, range, str
 from importlib.util import find_spec
 from pathlib import Path
 from typing import Dict, List, Optional
+import warnings
 
 import astromodels
 import astropy.units as u
@@ -1622,59 +1623,65 @@ class MLEResults(_AnalysisResults):
             # Make a fake covariance matrix
             covariance_matrix = np.zeros(expected_shape)
 
-        # Now reject the samples outside of the boundaries. If we reject more than 1% we
-        # warn the user
+        # Gather boundaries, replacing None/nan with -inf/inf
+        params = list(optimized_model.free_parameters.values())
+        param_names = [p.name for p in params]
 
-        # Gather boundaries
-        # NOTE: every None boundary will become nan thanks to the casting to float
-        low_bounds = np.array(
-            [
-                x._get_internal_min_value()
-                for x in list(optimized_model.free_parameters.values())
-            ],
-            float,
+        low_bounds = np.array([x._get_internal_min_value() for x in params], float)
+        hi_bounds = np.array([x._get_internal_max_value() for x in params], float)
+
+        low_bounds = np.where(np.isnan(low_bounds), -np.inf, low_bounds)
+        hi_bounds = np.where(np.isnan(hi_bounds), np.inf, hi_bounds)
+
+        # Vectorized boundary check
+        to_be_kept_mask = np.all(
+            (samples >= low_bounds) & (samples <= hi_bounds), axis=1
         )
-        hi_bounds = np.array(
-            [
-                x._get_internal_max_value()
-                for x in list(optimized_model.free_parameters.values())
-            ],
-            float,
-        )
-
-        # Fix all nans
-        low_bounds[np.isnan(low_bounds)] = -np.inf
-        hi_bounds[np.isnan(hi_bounds)] = np.inf
-
-        to_be_kept_mask = np.ones(samples.shape[0], bool)
-
-        for i, sample in enumerate(samples):
-            if np.any(sample > hi_bounds) or np.any(sample < low_bounds):
-                # Remove this sample
-                to_be_kept_mask[i] = False
-
-        # Compute how many samples we have removed
-        n_removed_samples = samples.shape[0] - np.sum(to_be_kept_mask)
-
-        # Warn the user if more than 1% of the samples have been lost
+        n_removed_samples = np.sum(~to_be_kept_mask)
 
         if n_removed_samples > samples.shape[0] / 100.0:
-            log.warning(
-                "%s percent of samples have been thrown away because they failed the "
-                "constraints on the parameters. This results might not be suitable for "
-                "error propagation. Enlarge the boundaries until you loose less than 1 "
-                "percent of the samples."
-                % (float(n_removed_samples) / samples.shape[0] * 100.0)
+            discarded = samples[~to_be_kept_mask].copy()
+
+            # Transform discarded samples to external space for reporting
+            for i, parameter in enumerate(params):
+                if parameter.has_transformation():
+                    discarded[:, i] = parameter.transformation.backward(discarded[:, i])
+
+            # Also transform bounds to external space
+            ext_low = low_bounds.copy()
+            ext_hi = hi_bounds.copy()
+            for i, parameter in enumerate(params):
+                if parameter.has_transformation():
+                    ext_low[i] = parameter.transformation.backward(low_bounds[i])
+                    ext_hi[i] = parameter.transformation.backward(hi_bounds[i])
+                    # Ensure low <= hi after transformation
+                    if ext_low[i] > ext_hi[i]:
+                        ext_low[i], ext_hi[i] = ext_hi[i], ext_low[i]
+
+            means = discarded.mean(axis=0)
+            stds = discarded.std(axis=0)
+
+            summary = "\n".join(
+                f"  {name}: mean={m:.4g}, std={s:.4g}, bounds=[{lo:.4g}, {hi:.4g}]"
+                for name, m, s, lo, hi in zip(param_names, means, stds, ext_low, ext_hi)
+            )
+            warnings.warn(
+                UserWarning(
+                    f"{n_removed_samples / samples.shape[0] * 100.0:.1f}% of samples have "
+                    "been thrown away because they failed the constraints on the "
+                    "parameters. This result might not be suitable for error propagation. "
+                    "Enlarge the boundaries until you lose less than 1% of the samples.\n"
+                    f"Discarded samples in excluded parameter space ({n_removed_samples} "
+                    f"samples):\n{summary}"
+                )
             )
 
-        # Now remove them
-        samples = samples[to_be_kept_mask, :]
+        samples = samples[to_be_kept_mask]
 
-        # Now transform in the external space
-        for i, parameter in enumerate(optimized_model.free_parameters.values()):
+        # Transform to external space
+        for i, parameter in enumerate(params):
             if parameter.has_transformation():
                 samples[:, i] = parameter.transformation.backward(samples[:, i])
-
         # Finally build the class
 
         super(MLEResults, self).__init__(

--- a/threeML/test/test_analysis_results.py
+++ b/threeML/test/test_analysis_results.py
@@ -4,12 +4,15 @@ from importlib.util import find_spec
 
 import astropy.units as u
 import numpy as np
-from astromodels import Powerlaw
+from astromodels.functions import Powerlaw
+import pytest
 
-from threeML import (
+from astromodels import (
     Model,
     PointSource,
 )
+from threeML import JointLikelihood, DataList
+from threeML.plugins.XYLike import XYLike
 from threeML.analysis_results import (
     AnalysisResultsSet,
     MLEResults,
@@ -375,3 +378,35 @@ def test_one_free_parameter_input_output():
     ar_reloaded = load_analysis_results(temp_file)
     os.remove(temp_file)
     _results_are_same(ar, ar_reloaded)
+
+
+def test_sample_frac_warning():
+    gen_function = Powerlaw()
+    gen_function.K.value = 100
+    gen_function.index.value = -3
+
+    x = np.logspace(0, 2, 50)
+
+    xyl_generator = XYLike.from_function(
+        "sim_data", function=gen_function, x=x, yerr=0.01 * gen_function(x)
+    )
+
+    y = xyl_generator.y
+    y_err = xyl_generator.yerr
+
+    pl = Powerlaw()
+    xyl = XYLike("data", x, y, y_err)
+    ps = PointSource("test", ra=0, dec=0, spectral_shape=pl)
+    pl.index.value = -2.7
+    pl.index.min_value = -2.8
+    pl.index.max_value = -2.6
+    pl.K.value = 100
+    pl.K.min_value = 105
+    pl.K.max_value = 115
+
+    model = Model(ps)
+    dl = DataList(xyl)
+    jl = JointLikelihood(model, dl)
+    with pytest.warns():
+        jl.fit()
+        print(jl.results)


### PR DESCRIPTION
We currently do not provide a lot information when initializing a MLEResult and a lot of "illegal" samples are created in the process, as usually the bounds are to tight.

This PR adds some more information on the discarded samples so the user can better debug the model - this is from the added test (both parameters converged against the lower bound):
```bash
  WARNING UserWarning: 73.6% of samples have been thrown away because they failed the constraints on the parameters. This result might not be suitable for error propagation. Enlarge the boundaries until you lose less than 1% of the samples.
  Discarded samples in excluded parameter space (3679 samples):
    K: mean=105, std=3.819e-08, bounds=[105, 115]
    index: mean=-2.8, std=1.2e-09, bounds=[-2.8, -2.6]
```

<!-- readthedocs-preview threeml start -->
----
📚 Documentation preview 📚: https://threeml--686.org.readthedocs.build/en/686/

<!-- readthedocs-preview threeml end -->