### PR TITLE
Add pocoMC sampler

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -49,3 +49,4 @@ dependencies:
   - pip:
     - autoemcee
     - chainconsumer
+    - pocomc

--- a/ci/environment_aarch64.yml
+++ b/ci/environment_aarch64.yml
@@ -36,3 +36,5 @@ dependencies:
     - pytest
     - pytest-cov
     - flake8
+    - pip:
+        - pocomc

--- a/ci/environment_fermi.yml
+++ b/ci/environment_fermi.yml
@@ -57,3 +57,4 @@ dependencies:
   - pip:
     - autoemcee
     - chainconsumer
+    - pocomc

--- a/ci/environment_macos-latest.yml
+++ b/ci/environment_macos-latest.yml
@@ -52,3 +52,4 @@ dependencies:
   - pip:
     - autoemcee
     - chainconsumer
+    - pocomc

--- a/ci/environment_xspec.yml
+++ b/ci/environment_xspec.yml
@@ -56,3 +56,4 @@ dependencies:
   - pip:
     - autoemcee
     - chainconsumer
+    - pocomc

--- a/threeML/analysis_results.py
+++ b/threeML/analysis_results.py
@@ -548,6 +548,10 @@ class _AnalysisResults(object):
             fits_file = AnalysisResultsFITS(self)
 
             fits_file.writeto(sanitize_filename(filename), overwrite=overwrite)
+            log.info(
+                "Successfully wrote the FITS result file to "
+                f"{sanitize_filename(filename)}"
+            )
 
         else:
             with h5py.File(sanitize_filename(filename), "w") as f:
@@ -556,6 +560,10 @@ class _AnalysisResults(object):
                 grp = f.create_group("AnalysisResults_0")
 
                 ANALYSIS_RESULTS_HDF(self, grp)
+            log.info(
+                "Successfully wrote the HDF5 result file to "
+                f"{sanitize_filename(filename)}"
+            )
 
     def get_variates(self, param_path: str) -> RandomVariates:
         """

--- a/threeML/bayesian/bayesian_analysis.py
+++ b/threeML/bayesian/bayesian_analysis.py
@@ -55,6 +55,11 @@ _possible_samplers = {
         "from threeML.bayesian.autoemcee_sampler import AutoEmceeSampler",
         "AutoEmceeSampler",
     ],
+    "pocomc": [
+        "pocomc",
+        "from threeML.bayesian.pocomc_sampler import PocoMCSampler",
+        "PocoMCSampler",
+    ],
 }
 
 
@@ -66,7 +71,8 @@ for k, v in _possible_samplers.items():
         exec(f"{v[1]}")
         exec(f"_available_samplers['{k}'] = {v[2]}")
 
-    except ImportError:
+    except ImportError as e:
+        log.debug(e)
         log.debug(f"no {v[0]}")
 
 

--- a/threeML/bayesian/pocomc_sampler.py
+++ b/threeML/bayesian/pocomc_sampler.py
@@ -1,6 +1,5 @@
 import logging
 from importlib.util import find_spec
-import numpy as np
 
 from astromodels import use_astromodels_memoization
 

--- a/threeML/bayesian/pocomc_sampler.py
+++ b/threeML/bayesian/pocomc_sampler.py
@@ -1,0 +1,94 @@
+import logging
+from importlib.util import find_spec
+
+from astromodels import use_astromodels_memoization
+
+from threeML.bayesian.sampler_base import MCMCSampler
+
+log = logging.getLogger(__name__)
+has_pocomc = False
+if find_spec("pocomc") is not None:
+    import pocomc as pc
+
+    has_pocomc = True
+has_mpi = False
+if find_spec("mpi4py") is not None:
+    from mpi4py.MPI import COMM_WORLD
+
+    comm = COMM_WORLD
+    if comm.Get_size() > 1:
+        has_mpi = True
+
+
+class PocoMCSampler(MCMCSampler):
+    def __init__(self, likelihood_model=None, data_list=None, **kwargs):
+        assert has_pocomc, "You must install pocomc to use this sampler"
+
+        super(PocoMCSampler, self).__init__(likelihood_model, data_list, **kwargs)
+
+    def get_posterior(self, trial_values) -> float:
+        for i, (parameter_name, parameter) in enumerate(self._free_parameters.items()):
+            parameter.value = trial_values[i]
+
+        return self._log_like(trial_values)
+
+    def setup(self, **kwargs):
+        """Set up the pocomc sampler.
+
+        :param n_iterations:
+        :type n_iterations:
+        :param n_burn_in:
+        :type n_burn_in:
+        :param n_walkers:
+        :type n_walkers:
+        :returns:
+        """
+        self._sampler_kwargs = kwargs
+        self._is_setup = True
+
+    def sample(self, **kwargs):
+        kwargs.pop("quiet")
+        if not self._is_setup:
+            log.info("You forgot to setup the sampler!")
+            return
+
+        self._update_free_parameters()
+        with use_astromodels_memoization(False):
+            prior = pc.Prior(
+                [
+                    p.prior.scipy_dist
+                    for p in list(self._likelihood_model.free_parameters.values())
+                ]
+            )
+
+            sampler = pc.Sampler(
+                prior=prior,
+                likelihood=self.get_posterior_proxy(),
+                **self._sampler_kwargs,
+            )
+
+            sampler.run(**kwargs)
+        self._sampler = sampler
+
+        samples, weights, logl, logp = sampler.posterior()
+        self._raw_samples = samples
+
+        print(f"THIS IS THE SAMPELS SHAPE: {samples.shape}")
+
+        self._log_like_values = logl
+        self._log_probability_values = self._log_like_values + logp
+
+        self._marginal_likelihood = None
+
+        self._build_samples_dictionary()
+
+        self._build_results()
+
+        # Display results
+        self._results.display()
+
+        return self.samples
+
+    @property
+    def n_walkers(self):
+        return self._n_walkers

--- a/threeML/bayesian/pocomc_sampler.py
+++ b/threeML/bayesian/pocomc_sampler.py
@@ -71,10 +71,8 @@ class PocoMCSampler(MCMCSampler):
         self._sampler = sampler
 
         samples, weights, logl, logp = sampler.posterior()
+
         self._raw_samples = samples
-
-        print(f"THIS IS THE SAMPELS SHAPE: {samples.shape}")
-
         self._log_like_values = logl
         self._log_probability_values = self._log_like_values + logp
 

--- a/threeML/bayesian/pocomc_sampler.py
+++ b/threeML/bayesian/pocomc_sampler.py
@@ -1,9 +1,11 @@
 import logging
 from importlib.util import find_spec
+import numpy as np
 
 from astromodels import use_astromodels_memoization
 
 from threeML.bayesian.sampler_base import MCMCSampler
+import multiprocessing as mp
 
 log = logging.getLogger(__name__)
 has_pocomc = False
@@ -11,6 +13,14 @@ if find_spec("pocomc") is not None:
     import pocomc as pc
 
     has_pocomc = True
+
+_WORKER_SAMPLER = None
+
+
+def _worker_logprob(theta):
+    return _WORKER_SAMPLER.get_posterior(theta)
+
+
 has_mpi = False
 if find_spec("mpi4py") is not None:
     from mpi4py.MPI import COMM_WORLD
@@ -27,6 +37,15 @@ class PocoMCSampler(MCMCSampler):
         super(PocoMCSampler, self).__init__(likelihood_model, data_list, **kwargs)
 
     def get_posterior(self, trial_values) -> float:
+        """
+        Workaround as pocomc needs a seperate prior/likelihood function. This function
+        sets the parameter values and returns the log likelihood value - not the
+        posterior! Named so because of
+
+        :param trial_values: The parameter values to evaluate the log likelihood at.
+        :type trial_values: list
+        """
+
         for i, (parameter_name, parameter) in enumerate(self._free_parameters.items()):
             parameter.value = trial_values[i]
 
@@ -54,6 +73,7 @@ class PocoMCSampler(MCMCSampler):
 
         self._update_free_parameters()
         with use_astromodels_memoization(False):
+
             prior = pc.Prior(
                 [
                     p.prior.scipy_dist
@@ -61,16 +81,30 @@ class PocoMCSampler(MCMCSampler):
                 ]
             )
 
-            sampler = pc.Sampler(
-                prior=prior,
-                likelihood=self.get_posterior_proxy(),
-                **self._sampler_kwargs,
-            )
+            if self._sampler_kwargs.get("pool", None) is not None:
+                global _WORKER_SAMPLER
+                _WORKER_SAMPLER = self
+                with mp.pool.Pool(int(self._sampler_kwargs.get("pool"))) as executor:
+                    self._sampler_kwargs.pop("pool")
+                    sampler = pc.Sampler(
+                        prior=prior,
+                        likelihood=_worker_logprob,
+                        pool=executor,
+                        **self._sampler_kwargs,
+                    )
 
-            sampler.run(**kwargs)
+                    sampler.run(**kwargs)
+            else:
+                sampler = pc.Sampler(
+                    prior=prior,
+                    likelihood=self.get_posterior_proxy(),
+                    **self._sampler_kwargs,
+                )
+
+                sampler.run(**kwargs)
+
         self._sampler = sampler
-
-        samples, weights, logl, logp = sampler.posterior()
+        samples, logl, logp = sampler.posterior(resample=True)
 
         self._raw_samples = samples
         self._log_like_values = logl

--- a/threeML/bayesian/pocomc_sampler.py
+++ b/threeML/bayesian/pocomc_sampler.py
@@ -80,8 +80,21 @@ class PocoMCSampler(MCMCSampler):
                 ]
             )
 
+            global _WORKER_SAMPLER
+            if has_mpi:
+                _WORKER_SAMPLER = self
+                with pc.parallel.MPIPool() as executor:
+                    self._sampler_kwargs.pop("pool")
+                    sampler = pc.Sampler(
+                        prior=prior,
+                        likelihood=_worker_logprob,
+                        pool=executor,
+                        **self._sampler_kwargs,
+                    )
+
+                    sampler.run(**kwargs)
+
             if self._sampler_kwargs.get("pool", None) is not None:
-                global _WORKER_SAMPLER
                 _WORKER_SAMPLER = self
                 with mp.pool.Pool(int(self._sampler_kwargs.get("pool"))) as executor:
                     self._sampler_kwargs.pop("pool")

--- a/threeML/bayesian/sampler_base.py
+++ b/threeML/bayesian/sampler_base.py
@@ -375,7 +375,7 @@ class SamplerBase(metaclass=abc.ABCMeta):
                 # Old way; every dataset independendly - This is fine if the
                 # spectrum calc is fast.
 
-                for i, dataset in enumerate(self._data_list.values()):
+                for i, dataset in enumerate(list(self._data_list.values())):
                     log_like_values[i] = dataset.get_log_like()
 
             else:

--- a/threeML/bayesian/sampler_base.py
+++ b/threeML/bayesian/sampler_base.py
@@ -288,10 +288,10 @@ class SamplerBase(metaclass=abc.ABCMeta):
         # self._update_free_parameters()
 
         if len(self._free_parameters) != len(trial_values):
-            msg = "Something is wrong. Number of free parameters\ndo not match the "
-            "number of trial values."
-
-            log.error(msg)
+            msg = (
+                "Something is wrong. Number of free parameters\ndo not match the "
+                + "number of trial values."
+            )
 
             raise AssertionError(msg)
 
@@ -437,6 +437,11 @@ class SamplerBase(metaclass=abc.ABCMeta):
             ]
 
             log.warning(f"Likelihood value is infinite for parameters: {params}")
+            vals = [
+                f"{d.name}: {v}"
+                for d, v in zip(self._data_list.values(), log_like_values)
+            ]
+            log.warning(f"Likelihood values for the individual plugins: {vals}")
 
             return -np.inf
 
@@ -500,7 +505,7 @@ class UnitCubeSampler(SamplerBase):
             return log_like
 
         # Now construct the prior
-        # MULTINEST priors are defined on the unit cube
+        # UnitCubeSampler priors are defined on the unit cube
         # and should return the value in the bounds... not the
         # probability. Therefore, we must make some transforms
 

--- a/threeML/bayesian/sampler_base.py
+++ b/threeML/bayesian/sampler_base.py
@@ -1,7 +1,6 @@
-import logging
-
 import abc
 import collections
+import logging
 import math
 import weakref
 from typing import Dict, Optional
@@ -32,7 +31,6 @@ from astromodels.functions.function import ModelAssertionViolation
 
 from threeML.analysis_results import BayesianResults
 from threeML.data_list import DataList
-
 from threeML.utils.numba_utils import nb_sum
 from threeML.utils.spectrum.share_spectrum import ShareSpectrum
 from threeML.utils.statistics.stats_tools import aic, bic, dic
@@ -282,62 +280,44 @@ class SamplerBase(metaclass=abc.ABCMeta):
     def get_posterior(self, trial_values) -> float:
         """Compute the posterior for the normal sampler."""
 
-        # Assign this trial values to the parameters and
-        # store the corresponding values for the priors
-
-        # self._update_free_parameters()
+        # Assign this trial values to the parameters and store the corresponding
+        # values for the priors.
 
         if len(self._free_parameters) != len(trial_values):
             msg = (
-                "Something is wrong. Number of free parameters\ndo not match the "
-                + "number of trial values."
+                "Something is wrong. Number of free parameters\n"
+                "do not match the number of trial values."
             )
 
             raise AssertionError(msg)
 
-        log_prior = 0
-
-        # with use_
+        log_prior = 0.0
 
         for i, (parameter_name, parameter) in enumerate(self._free_parameters.items()):
             prior_value = parameter.prior(trial_values[i])
 
             if prior_value == 0:
                 # Outside allowed region of parameter space
-
                 return -np.inf
 
-            else:
-                parameter.value = trial_values[i]
+            parameter.value = trial_values[i]
 
-                log_prior += math.log(prior_value)
+            log_prior += math.log(prior_value)
 
         log_like = self._log_like(trial_values)
-
-        # print("Log like is %s, log_prior is %s, for trial values %s" % (log_like,
-        # log_prior,trial_values))
 
         return log_like + log_prior
 
     def get_posterior_proxy(self):
         """
-        Return a weakref-backed posterior callable.
+        Return a weakref-backed, pickleable posterior callable.
 
-        This prevents external samplers from keeping a strong reference to this
-        SamplerBase instance via a bound method.
+        The returned object does not keep a strong reference to this SamplerBase
+        instance in the parent process, but it can still be serialized and sent to
+        multiprocessing/MPI workers.
         """
 
-        sampler_ref = weakref.ref(self)
-
-        def posterior(trial_values):
-            sampler = sampler_ref()
-
-            if sampler is None:
-                return -np.inf
-
-            return sampler.get_posterior(trial_values)
-
-        return posterior
+        return PosteriorProxy(self)
 
     def _log_prior(self, trial_values) -> float:
         """Compute the sum of log-priors, used in the parallel tempering
@@ -572,3 +552,83 @@ def arg_median(a):
         left = np.partition(a, l)[l]
         right = np.partition(a, r)[r]
         return min([np.where(a == left)[0][0], np.where(a == right)[0][0]])
+
+
+class PosteriorProxy:
+    """
+    Pickleable posterior callable.
+
+    In the parent process this keeps only a weak reference to the sampler, so
+    external samplers do not keep the SamplerBase instance alive unnecessarily.
+
+    When pickled and sent to a worker process, the underlying sampler is
+    serialized and restored as a strong reference inside that worker. This is
+    necessary because a weakref to an object in another process would be useless.
+
+    Thanks Claude :)
+    """
+
+    def __init__(self, sampler):
+        # In the parent/main process, avoid keeping sampler alive.
+        self._sampler_ref = weakref.ref(sampler)
+
+        # This is only used after unpickling in a worker process.
+        self._sampler = None
+
+    def _get_sampler(self):
+        """
+        Return the sampler either from the local strong reference, used in
+        workers, or from the weak reference, used in the parent process.
+        """
+
+        if self._sampler is not None:
+            return self._sampler
+
+        if self._sampler_ref is None:
+            return None
+
+        return self._sampler_ref()
+
+    def __call__(self, trial_values):
+        sampler = self._get_sampler()
+
+        if sampler is None:
+            return -np.inf
+
+        return sampler.get_posterior(trial_values)
+
+    def __getstate__(self):
+        """
+        Customize pickling.
+
+        A weakref.ref object cannot meaningfully be pickled for execution in
+        another process. Therefore, when this proxy is pickled, dereference the
+        weakref and serialize the actual sampler.
+
+        This does not make the parent-side PosteriorProxy hold a permanent
+        strong reference. It only creates a strong reference during pickling.
+        """
+
+        sampler = self._get_sampler()
+
+        if sampler is None:
+            raise RuntimeError(
+                "Cannot pickle PosteriorProxy because the referenced sampler "
+                "has already been garbage-collected."
+            )
+
+        return {
+            "sampler": sampler,
+        }
+
+    def __setstate__(self, state):
+        """
+        Restore state in a worker process.
+
+        In the worker process we intentionally keep a strong reference to the
+        sampler. The worker needs a real sampler object to evaluate the
+        posterior.
+        """
+
+        self._sampler = state["sampler"]
+        self._sampler_ref = None

--- a/threeML/bayesian/zeus_sampler.py
+++ b/threeML/bayesian/zeus_sampler.py
@@ -1,4 +1,6 @@
 import logging
+from importlib.util import find_spec
+import multiprocessing as mp
 
 import numpy as np
 from astromodels import use_astromodels_memoization
@@ -8,35 +10,19 @@ from threeML.config.config import threeML_config
 
 from threeML.parallel.parallel_client import ParallelClient
 
-try:
+log = logging.getLogger(__name__)
+has_zeus = False
+if find_spec("zeus") is not None:
     import zeus
 
-except Exception:
-    has_zeus = False
-
-else:
     has_zeus = True
+has_mpi = False
+if find_spec("mpi4py") is not None:
+    from mpi4py.MPI import COMM_WORLD
 
-
-try:
-    # see if we have mpi and/or are using parallel
-
-    from mpi4py import MPI
-
-    if MPI.COMM_WORLD.Get_size() > 1:  # need parallel capabilities
-        using_mpi = True
-
-        comm = MPI.COMM_WORLD
-        rank = comm.Get_rank()
-
-        from mpi4py.futures import MPIPoolExecutor
-
-    else:
-        using_mpi = False
-except Exception:
-    using_mpi = False
-
-log = logging.getLogger(__name__)
+    comm = COMM_WORLD
+    if comm.Get_size() > 1:
+        has_mpi = True
 
 
 class ZeusSampler(MCMCSampler):
@@ -45,7 +31,7 @@ class ZeusSampler(MCMCSampler):
 
         super(ZeusSampler, self).__init__(likelihood_model, data_list, **kwargs)
 
-    def setup(self, n_iterations, n_burn_in=None, n_walkers=20):
+    def setup(self, n_iterations, n_burn_in=None, n_walkers=None, **kwargs):
         """Set up the zeus sampler.
 
         :param n_iterations:
@@ -68,12 +54,19 @@ class ZeusSampler(MCMCSampler):
 
         else:
             self._n_burn_in = n_burn_in
+        if n_walkers is None:
+            n_walkers = int(len(self._likelihood_model.free_parameters.values())) * 2
+            log.warning(
+                "You did not provide 'n_walkers' for the zeus setup - will set it to a"
+                " default of 2x the number of free parameters"
+            )
 
         self._n_walkers = int(n_walkers)
+        self._sampler_kwargs = kwargs
 
         self._is_setup = True
 
-    def sample(self, quiet=False):
+    def sample(self, quiet=False, n_chains=1, p0=None, **kwargs):
         if not self._is_setup:
             log.info("You forgot to setup the sampler!")
             return
@@ -85,30 +78,32 @@ class ZeusSampler(MCMCSampler):
         n_dim = len(list(self._free_parameters.keys()))
 
         # Get starting point
-
-        p0 = self._get_starting_points(self._n_walkers)
+        if p0 is None:
+            p0 = np.array(self._get_starting_points(self._n_walkers, variance=0.3))
 
         # Deactivate memoization in astromodels, which is useless in this case since we
         # will never use twice the same set of parameters
+        using_mpi = False
         with use_astromodels_memoization(False):
-            if using_mpi:
-                with MPIPoolExecutor() as executor:
+            if has_mpi:
+                with zeus.ChainManager(n_chains, use_dill=False) as cm:
                     sampler = zeus.EnsembleSampler(
-                        logprob_fn=self.get_posterior_proxy(),
+                        logprob_fn=self.get_posterior,
                         nwalkers=self._n_walkers,
                         ndim=n_dim,
-                        pool=executor,
+                        pool=cm.get_pool,
+                        verbose=loud,
                     )
 
                     # Run the true sampling
                     log.debug("Start zeus run")
+                    using_mpi = True
                     _ = sampler.run_mcmc(
                         p0,
                         self._n_iterations + self._n_burn_in,
                         progress=loud,
                     )
                     log.debug("Zeus run done")
-
             elif threeML_config["parallel"]["use_parallel"]:
                 c = ParallelClient()
                 view = c[:]
@@ -118,13 +113,31 @@ class ZeusSampler(MCMCSampler):
                     nwalkers=self._n_walkers,
                     ndim=n_dim,
                     pool=view,
+                    verbose=loud,
                 )
+            elif self._sampler_kwargs.get("pool", None) is not None:
+                with mp.pool.Pool(int(self._sampler_kwargs.get("pool"))) as executor:
+                    sampler = zeus.EnsembleSampler(
+                        logprob_fn=self.get_posterior,
+                        nwalkers=self._n_walkers,
+                        ndim=n_dim,
+                        pool=executor,
+                        verbose=loud,
+                    )
+                    sampler.run_mcmc(
+                        p0,
+                        self._n_iterations + self._n_burn_in,
+                        progress=loud,
+                    )
+                    using_mpi = True
 
             else:
                 sampler = zeus.EnsembleSampler(
-                    logprob_fn=self.get_posterior_proxy(),
+                    logprob_fn=self.get_posterior,
                     nwalkers=self._n_walkers,
                     ndim=n_dim,
+                    verbose=loud,
+                    **kwargs,
                 )
 
             # Sample the burn-in
@@ -168,3 +181,7 @@ class ZeusSampler(MCMCSampler):
             self._results.display()
 
         return self.samples
+
+    @property
+    def n_walkers(self):
+        return self._n_walkers

--- a/threeML/bayesian/zeus_sampler.py
+++ b/threeML/bayesian/zeus_sampler.py
@@ -7,7 +7,6 @@ from astromodels import use_astromodels_memoization
 
 from threeML.bayesian.sampler_base import MCMCSampler
 from threeML.config.config import threeML_config
-
 from threeML.parallel.parallel_client import ParallelClient
 
 log = logging.getLogger(__name__)
@@ -127,18 +126,23 @@ class ZeusSampler(MCMCSampler):
                     verbose=loud,
                 )
             elif self._sampler_kwargs.get("pool", None) is not None:
+                _WORKER_SAMPLER = self
+
                 with mp.pool.Pool(int(self._sampler_kwargs.get("pool"))) as executor:
+                    self._sampler_kwargs.pop("pool")
                     sampler = zeus.EnsembleSampler(
-                        logprob_fn=self.get_posterior_proxy(),
+                        logprob_fn=_worker_logprob,
                         nwalkers=self._n_walkers,
                         ndim=n_dim,
                         pool=executor,
                         verbose=loud,
+                        **self._sampler_kwargs,
                     )
                     sampler.run_mcmc(
                         p0,
                         self._n_iterations + self._n_burn_in,
                         progress=loud,
+                        **kwargs,
                     )
                     using_mpi = True
 
@@ -148,14 +152,14 @@ class ZeusSampler(MCMCSampler):
                     nwalkers=self._n_walkers,
                     ndim=n_dim,
                     verbose=loud,
-                    **kwargs,
+                    **self._sampler_kwargs,
                 )
 
             # Sample the burn-in
             if not using_mpi:
                 log.debug("Start zeus run")
                 _ = sampler.run_mcmc(
-                    p0, self._n_iterations + self._n_burn_in, progress=loud
+                    p0, self._n_iterations + self._n_burn_in, progress=loud, **kwargs
                 )
                 log.debug("Zeus run done")
 

--- a/threeML/bayesian/zeus_sampler.py
+++ b/threeML/bayesian/zeus_sampler.py
@@ -192,7 +192,12 @@ class ZeusSampler(MCMCSampler):
 
         # Display results
         if loud:
-            print(self._sampler.summary)
+            try:
+                # honestly no idea why the autocorrelation computation sometimes
+                # fails for this within zeus
+                log.warning(sampler.summary)
+            except IndexError:
+                pass
             self._results.display()
 
         return self.samples

--- a/threeML/bayesian/zeus_sampler.py
+++ b/threeML/bayesian/zeus_sampler.py
@@ -114,7 +114,7 @@ class ZeusSampler(MCMCSampler):
                     )
 
                     log.debug("Zeus run done")
-                    using_mpi = True
+                using_mpi = True
             elif threeML_config["parallel"]["use_parallel"]:
                 c = ParallelClient()
                 view = c[:]
@@ -140,7 +140,7 @@ class ZeusSampler(MCMCSampler):
                         self._n_iterations + self._n_burn_in,
                         progress=loud,
                     )
-                    using_mpi = True
+                using_mpi = True
 
             else:
                 sampler = zeus.EnsembleSampler(

--- a/threeML/bayesian/zeus_sampler.py
+++ b/threeML/bayesian/zeus_sampler.py
@@ -1,6 +1,6 @@
 import logging
-from importlib.util import find_spec
 import multiprocessing as mp
+from importlib.util import find_spec
 
 import numpy as np
 from astromodels import use_astromodels_memoization
@@ -16,11 +16,20 @@ if find_spec("zeus") is not None:
     import zeus
 
     has_zeus = True
+
+_WORKER_SAMPLER = None
+
+
+def _worker_logprob(theta):
+    return _WORKER_SAMPLER.get_posterior(theta)
+
+
 has_mpi = False
 if find_spec("mpi4py") is not None:
-    from mpi4py.MPI import COMM_WORLD
+    from mpi4py import MPI
+    from zeus import ChainManager
 
-    comm = COMM_WORLD
+    comm = MPI.COMM_WORLD
     if comm.Get_size() > 1:
         has_mpi = True
 
@@ -86,24 +95,26 @@ class ZeusSampler(MCMCSampler):
         using_mpi = False
         with use_astromodels_memoization(False):
             if has_mpi:
-                with zeus.ChainManager(n_chains, use_dill=False) as cm:
+                global _WORKER_SAMPLER
+                _WORKER_SAMPLER = self
+
+                with ChainManager(n_chains) as cm:
+                    # Every rank already has self in memory
                     sampler = zeus.EnsembleSampler(
-                        logprob_fn=self.get_posterior,
                         nwalkers=self._n_walkers,
                         ndim=n_dim,
+                        logprob_fn=_worker_logprob,
                         pool=cm.get_pool,
-                        verbose=loud,
                     )
 
-                    # Run the true sampling
-                    log.debug("Start zeus run")
-                    using_mpi = True
-                    _ = sampler.run_mcmc(
+                    sampler.run_mcmc(
                         p0,
                         self._n_iterations + self._n_burn_in,
                         progress=loud,
                     )
+
                     log.debug("Zeus run done")
+                    using_mpi = True
             elif threeML_config["parallel"]["use_parallel"]:
                 c = ParallelClient()
                 view = c[:]
@@ -118,7 +129,7 @@ class ZeusSampler(MCMCSampler):
             elif self._sampler_kwargs.get("pool", None) is not None:
                 with mp.pool.Pool(int(self._sampler_kwargs.get("pool"))) as executor:
                     sampler = zeus.EnsembleSampler(
-                        logprob_fn=self.get_posterior,
+                        logprob_fn=self.get_posterior_proxy(),
                         nwalkers=self._n_walkers,
                         ndim=n_dim,
                         pool=executor,
@@ -133,7 +144,7 @@ class ZeusSampler(MCMCSampler):
 
             else:
                 sampler = zeus.EnsembleSampler(
-                    logprob_fn=self.get_posterior,
+                    logprob_fn=self.get_posterior_proxy(),
                     nwalkers=self._n_walkers,
                     ndim=n_dim,
                     verbose=loud,

--- a/threeML/plugins/DispersionSpectrumLike.py
+++ b/threeML/plugins/DispersionSpectrumLike.py
@@ -130,14 +130,6 @@ class DispersionSpectrumLike(SpectrumLike):
         # Get the differential flux function, and the integral function, with no
         # dispersion, we simply integrate the model over the bins
 
-        differential_flux, integral = self._get_diff_flux_and_integral(
-            self._like_model, integrate_method=self._model_integrate_method
-        )
-
-        log.debug(f"{self._name} passing integral flux function to RSP")
-
-        self._integral_flux = integral
-
         # pass to the response matrix
 
         self._response.set_function(self._integral_flux)
@@ -162,7 +154,7 @@ class DispersionSpectrumLike(SpectrumLike):
 
         # if like_model already set, upadte the integral function
         if self._like_model is not None:
-            differential_flux, integral = self._get_diff_flux_and_integral(
+            integral = self._get_diff_flux_and_integral(
                 self._like_model, integrate_method=method
             )
 

--- a/threeML/plugins/SpectrumLike.py
+++ b/threeML/plugins/SpectrumLike.py
@@ -2,14 +2,11 @@ import logging
 
 import collections
 import copy
-import types
 from contextlib import contextmanager
 from typing import Any, Dict, Optional, Tuple, Union
-from packaging.version import Version
 
 import matplotlib
 import matplotlib.pyplot as plt
-import numba as nb
 import numpy as np
 import pandas as pd
 from astromodels import Model, PointSource, clone_model
@@ -37,6 +34,15 @@ from threeML.utils.spectrum.binned_spectrum import (
 )
 from threeML.utils.spectrum.pha_spectrum import PHASpectrum
 from threeML.utils.spectrum.spectrum_likelihood import statistic_lookup
+from threeML.utils.spectrum.integration_functions import (
+    simpson_integral_values,
+    simpson_integral_edges,
+    trapz_integral_edges,
+    trapz_integral_values,
+    riemann_integral_edges,
+    riemann_integral_values,
+)
+
 from threeML.utils.statistics.stats_tools import Significance
 from threeML.utils.string_utils import dash_separated_string_to_tuple
 
@@ -52,13 +58,6 @@ __instrument_name = "General binned spectral data"
 
 # This defines the known noise models for source and/or background spectra
 _known_noise_models = ["poisson", "gaussian", "ideal", "modeled"]
-
-
-np_version = Version(np.__version__)
-if np_version < Version("2.0.0"):
-    trapezoid = np.trapz
-else:
-    trapezoid = np.trapezoid
 
 
 class SpectrumLike(PluginPrototype):
@@ -210,12 +209,7 @@ class SpectrumLike(PluginPrototype):
 
                 # now get the background likelihood model
 
-                differential_flux, integral = self._get_diff_flux_and_integral(
-                    self._background_plugin.likelihood_model,
-                    integrate_method=self._background_integrate_method,
-                )
-
-                self._background_integral_flux = integral
+                self._background_integral_flux = self._background_plugin.integral_flux
 
         super(SpectrumLike, self).__init__(name, nuisance_parameters)
 
@@ -1907,12 +1901,6 @@ class SpectrumLike(PluginPrototype):
         # Get the differential flux function, and the integral function, with no
         # dispersion, we simply integrate the model over the bins
 
-        differential_flux, integral = self._get_diff_flux_and_integral(
-            self._like_model, integrate_method=self._model_integrate_method
-        )
-
-        self._integral_flux = integral
-
     def _evaluate_model(self, precalc_fluxes: Optional[np.array] = None) -> np.ndarray:
         """Since there is no dispersion, we simply evaluate the model by
         integrating over the energy bins. This can be overloaded to convolve
@@ -2021,16 +2009,9 @@ class SpectrumLike(PluginPrototype):
 
         return model
 
-    def _get_diff_flux_and_integral(
-        self, likelihood_model: Model, integrate_method: str = "simpson"
-    ) -> Tuple[types.FunctionType, types.FunctionType]:
-
-        if integrate_method not in ["simpson", "trapz", "riemann"]:
-
-            log.error("Only simpson and trapz are valid integral_methods.")
-
-            raise RuntimeError()
-
+    def _differential_flux(self, energies, likelihood_model=None):
+        if likelihood_model is None:
+            likelihood_model = self._like_model
         if self._source_name is None:
 
             log.debug(f"{self.name} is using all point sources")
@@ -2040,18 +2021,17 @@ class SpectrumLike(PluginPrototype):
             # Make a function which will stack all point sources (OGIP do not support
             # spatial dimension)
 
-            def differential_flux(energies):
-                fluxes = likelihood_model.get_point_source_fluxes(
-                    0, energies, tag=self._tag, stokes=self._stokes
+            fluxes = likelihood_model.get_point_source_fluxes(
+                0, energies, tag=self._tag, stokes=self._stokes
+            )
+
+            # If we have only one point source, this will never be executed
+            for i in range(1, n_point_sources):
+                fluxes += likelihood_model.get_point_source_fluxes(
+                    i, energies, tag=self._tag, stokes=self._stokes
                 )
 
-                # If we have only one point source, this will never be executed
-                for i in range(1, n_point_sources):
-                    fluxes += likelihood_model.get_point_source_fluxes(
-                        i, energies, tag=self._tag, stokes=self._stokes
-                    )
-
-                return fluxes
+            return fluxes
 
         else:
 
@@ -2059,17 +2039,12 @@ class SpectrumLike(PluginPrototype):
 
             # Note that we checked that self._source_name is in the model when the model
             # was set
-
             try:
-
-                def differential_flux(energies):
-
-                    return likelihood_model.sources[self._source_name](
-                        energies, tag=self._tag, stokes=self._stokes
-                    )
-
                 log.debug(
                     f"{self.name} is using only the point source {self._source_name}"
+                )
+                return likelihood_model.sources[self._source_name](
+                    energies, tag=self._tag, stokes=self._stokes
                 )
 
             except KeyError:
@@ -2081,70 +2056,32 @@ class SpectrumLike(PluginPrototype):
 
                 raise KeyError()
 
-        # The following integrates the diffFlux function using Simpson's rule
-        # This assume that the intervals e1,e2 are all small, which is guaranteed
-        # for any reasonable response matrix, given that e1 and e2 are Monte-Carlo
-        # energies. It also assumes that the function is smooth in the interval
-        # e1 - e2 and twice-differentiable, again reasonable on small intervals for
-        # decent models. It might fail for models with too sharp features, smaller
-        # than the size of the monte carlo interval.
+    def _integral_flux(self, *args, **kwargs):
 
-        if integrate_method == "simpson":
+        if self._model_integrate_method not in ["simpson", "trapz", "riemann"]:
+            log.error("Only simpson, trapz and riemann are valid integral_methods.")
+            raise RuntimeError()
 
-            # New way with simpson rule.
-            # Make sure to not calculate the model twice for the same energies
-
+        if self._model_integrate_method == "simpson":
             if self._has_contiguous_energies:
-
                 if self._predefined_energies is None:
-
-                    def integral(e_edges):
-
-                        # Make sure we do not calculate the flux two times at the same
-                        # energy
-                        # e_edges = np.append(e1, e2[-1])
-                        e_m = (e_edges[1:] + e_edges[:-1]) / 2.0
-
-                        diff_fluxes_edges = differential_flux(e_edges)
-                        diff_fluxes_mid = differential_flux(e_m)
-
-                        return _simps(
-                            e_edges[:-1],
-                            e_edges[1:],
-                            diff_fluxes_edges,
-                            diff_fluxes_mid,
-                        )
-
-                else:
-
-                    e_edges = np.array(self._predefined_energies)
-                    ee1 = e_edges[:-1]
-                    ee2 = e_edges[1:]
-
-                    e_m = (ee1 + ee2) / 2.0
-
-                    def integral():
-
-                        diff_fluxes_edges = differential_flux(e_edges)
-                        diff_fluxes_mid = differential_flux(e_m)
-
-                        return _simps(ee1, ee2, diff_fluxes_edges, diff_fluxes_mid)
-
-            else:
-
-                def integral(e1, e2):
-                    # single energy values given
-                    return (
-                        (e2 - e1)
-                        / 6.0
-                        * (
-                            differential_flux(e1)
-                            + 4 * differential_flux((e2 + e1) / 2.0)
-                            + differential_flux(e2)
-                        )
+                    assert len(args[0]) > 1
+                    return simpson_integral_edges(
+                        args[0], diff_flux_method=self._differential_flux
                     )
 
-        elif integrate_method == "trapz":
+                else:
+                    e_edges = np.array(self._predefined_energies)
+                    return simpson_integral_edges(
+                        e_edges, diff_flux_method=self._differential_flux
+                    )
+
+            else:
+                return simpson_integral_values(
+                    args[0], args[1], diff_flux_method=self._differential_flux
+                )
+
+        elif self._model_integrate_method == "trapz":
 
             if self._has_contiguous_energies:
 
@@ -2155,27 +2092,16 @@ class SpectrumLike(PluginPrototype):
                 else:
 
                     e_edges = np.array(self._predefined_energies)
-                    ee1 = e_edges[:-1]
-                    ee2 = e_edges[1:]
-
-                    def integral():
-                        diff_fluxes_edges = differential_flux(e_edges)
-
-                        return _trapz(
-                            np.array([diff_fluxes_edges[:-1], diff_fluxes_edges[1:]]).T,
-                            np.array([ee1, ee2]).T,
-                        )
-
-            else:
-
-                def integral(e1, e2):
-                    # single energy values given
-                    return _trapz(
-                        np.array([differential_flux(e1), differential_flux(e2)]),
-                        np.array([e1, e2]),
+                    return trapz_integral_edges(
+                        e_edges, diff_flux_method=self._differential_flux
                     )
 
-        elif integrate_method == "riemann":
+            else:
+                return trapz_integral_values(
+                    args[0], args[1], diff_flux_method=self._differential_flux
+                )
+
+        elif self._model_integrate_method == "riemann":
 
             if self._has_contiguous_energies:
 
@@ -2186,25 +2112,18 @@ class SpectrumLike(PluginPrototype):
                 else:
 
                     e_edges = np.array(self._predefined_energies)
-                    ee1 = e_edges[:-1]
-                    ee2 = e_edges[1:]
-
-                    e_m = (ee1 + ee2) / 2.0
-
-                    # energy width
-                    de = ee2 - ee1
-
-                    def integral():
-
-                        return _rsum(differential_flux(e_m), de)
+                    return riemann_integral_edges(
+                        e_edges, diff_flux_method=self._differential_flux
+                    )
 
             else:
+                return riemann_integral_values(
+                    args[0], args[1], diff_flux_method=self._differential_flux
+                )
 
-                def integral(e1, e2):
-
-                    return differential_flux(0.5 * (e1 + e2)) * (e2 - e1)
-
-        return differential_flux, integral
+    @property
+    def integral_flux(self):
+        return self._integral_flux
 
     def use_effective_area_correction(
         self,
@@ -2277,13 +2196,6 @@ class SpectrumLike(PluginPrototype):
         self._model_integrate_method = method
         log.info(f"{self._name} changing model integration method to {method}")
 
-        # if like_model already set, upadte the integral function
-        if self._like_model is not None:
-            differential_flux, integral = self._get_diff_flux_and_integral(
-                self._like_model, integrate_method=method
-            )
-            self._integral_flux = integral
-
     def __set_model_integrate_method(self, value: str) -> None:
 
         self.set_model_integrate_method(value)
@@ -2311,7 +2223,7 @@ class SpectrumLike(PluginPrototype):
         method: (str) which method should be used (simpson or trapz)"""
         if method not in ["simpson", "trapz", "riemann"]:
 
-            log.error("Only simpson and trapz are valid intergate methods.")
+            log.error("Only simpson,trapz and riemann are valid intergate methods.")
 
             raise RuntimeError()
 
@@ -2320,11 +2232,8 @@ class SpectrumLike(PluginPrototype):
 
         # if background_plugin is set, update the integral function
         if self._background_plugin is not None:
-            differential_flux, integral = self._get_diff_flux_and_integral(
-                self._background_plugin.likelihood_model,
-                integrate_method=method,
-            )
-            self._background_integral_flux = integral
+            self._background_plugin.model_integrate_method = method
+            self._background_integral_flux = self._background_plugin.integral_flux
 
     def __set_background_integrate_method(self, value: str) -> None:
 
@@ -3746,23 +3655,3 @@ class SpectrumLike(PluginPrototype):
             yscale="log",
             show_legend=show_legend,
         )
-
-
-@nb.njit(fastmath=True, cache=True)
-def _trapz(x, y):  # pragma: no cover
-    return trapezoid(x, y)
-
-
-@nb.njit(fastmath=True, cache=True)
-def _simps(e1, e2, diff_fluxes_edges, diff_fluxes_mid):  # pragma: no cover
-    return (
-        (e2 - e1)
-        / 6.0
-        * (diff_fluxes_edges[:-1] + 4 * diff_fluxes_mid + diff_fluxes_edges[1:])
-    )
-
-
-@nb.njit(fastmath=True, cache=True)
-def _rsum(model_mid_points, de):  # pragma: no cover
-
-    return np.multiply(model_mid_points, de)

--- a/threeML/test/test_bayesian.py
+++ b/threeML/test/test_bayesian.py
@@ -297,7 +297,7 @@ def test_pocomc(bayes_fitter, completed_bn090217206_bayesian_analysis):
     bayes.set_sampler("pocomc")
     assert bayes.sample() is None
 
-    bayes.sampler.setup(n_effective=1024, precondition=False)
+    bayes.sampler.setup()
 
     bayes.sample()
 

--- a/threeML/test/test_bayesian.py
+++ b/threeML/test/test_bayesian.py
@@ -77,6 +77,18 @@ skip_if_nautilus_is_not_available = pytest.mark.skipif(
     not has_nautilus, reason="No nautilus available"
 )
 
+try:
+    import pocomc
+
+    print(pocomc.__doc__)
+except ModuleNotFoundError:
+    has_pocomc = False
+else:
+    has_pocomc = True
+skip_if_pocomc_is_not_available = pytest.mark.skipif(
+    not has_pocomc, reason="No pocomc available"
+)
+
 
 def remove_priors(model):
     for parameter in model:
@@ -248,6 +260,26 @@ def test_nautilus(bayes_fitter, completed_bn090217206_bayesian_analysis):
     bayes.sample()
 
     res = bayes.results.get_data_frame()
+
+    bayes.restore_median_fit()
+
+    check_results(res)
+
+
+@skip_if_pocomc_is_not_available
+def test_pocomc(bayes_fitter, completed_bn090217206_bayesian_analysis):
+    bayes, _ = completed_bn090217206_bayesian_analysis
+
+    bayes.set_sampler("pocomc")
+    assert bayes.sample() is None
+
+    bayes.sampler.setup(n_effective=1024, precondition=False)
+
+    bayes.sample()
+
+    res = bayes.results.get_data_frame()
+
+    bayes.results.write_to("/home/tobi/sw/threeML/poco_test.fits", overwrite=True)
 
     bayes.restore_median_fit()
 

--- a/threeML/test/test_bayesian.py
+++ b/threeML/test/test_bayesian.py
@@ -279,8 +279,6 @@ def test_pocomc(bayes_fitter, completed_bn090217206_bayesian_analysis):
 
     res = bayes.results.get_data_frame()
 
-    bayes.results.write_to("/home/tobi/sw/threeML/poco_test.fits", overwrite=True)
-
     bayes.restore_median_fit()
 
     check_results(res)

--- a/threeML/test/test_bayesian.py
+++ b/threeML/test/test_bayesian.py
@@ -247,6 +247,30 @@ def test_zeus(bayes_fitter, completed_bn090217206_bayesian_analysis):
     check_results(res)
 
 
+@skip_if_zeus_is_not_available
+def test_zeus_automatic_convergence(
+    bayes_fitter, completed_bn090217206_bayesian_analysis
+):
+    bayes, _ = completed_bn090217206_bayesian_analysis
+
+    bayes.set_sampler("zeus")
+    assert bayes.sample() is None
+
+    cb0 = zeus.callbacks.AutocorrelationCallback(
+        ncheck=100, dact=0.01, nact=50, discard=0.5
+    )
+    cb1 = zeus.callbacks.MinIterCallback(nmin=1000)
+    bayes.sampler.setup(n_iterations=20000, n_walkers=4, n_burn_in=0)
+
+    bayes.sample(callbacks=[cb0, cb1])
+
+    res = bayes.results.get_data_frame()
+
+    bayes.restore_median_fit()
+
+    check_results(res)
+
+
 @pytest.mark.filterwarnings("ignore:You provided")
 @skip_if_nautilus_is_not_available
 def test_nautilus(bayes_fitter, completed_bn090217206_bayesian_analysis):

--- a/threeML/utils/OGIP/response.py
+++ b/threeML/utils/OGIP/response.py
@@ -231,9 +231,7 @@ class InstrumentResponse(object):
         """
         if precalc_fluxes is None:
             try:
-                fluxes = self._integral_function(
-                    # self._monte_carlo_energies[:-1], self._monte_carlo_energies[1:]
-                )
+                fluxes = self._integral_function()
             except TypeError:
                 fluxes = self._integral_function(
                     self._monte_carlo_energies[:-1],

--- a/threeML/utils/spectrum/integration_functions.py
+++ b/threeML/utils/spectrum/integration_functions.py
@@ -1,0 +1,90 @@
+import numpy as np
+
+from packaging.version import Version
+
+np_version = Version(np.__version__)
+if np_version < Version("2.0.0"):
+    trapezoid = np.trapz
+else:
+    trapezoid = np.trapezoid
+
+
+def _trapz(x, y):
+    return trapezoid(x, y)
+
+
+def _simps(e1, e2, diff_fluxes_edges, diff_fluxes_mid):
+    return (
+        (e2 - e1)
+        / 6.0
+        * (diff_fluxes_edges[:-1] + 4 * diff_fluxes_mid + diff_fluxes_edges[1:])
+    )
+
+
+def _rsum(model_mid_points, de):
+
+    return np.multiply(model_mid_points, de)
+
+
+def simpson_integral_edges(e_edges, diff_flux_method):
+
+    e_m = (e_edges[1:] + e_edges[:-1]) / 2.0
+
+    diff_fluxes_edges = diff_flux_method(e_edges)
+    diff_fluxes_mid = diff_flux_method(e_m)
+
+    return _simps(
+        e_edges[:-1],
+        e_edges[1:],
+        diff_fluxes_edges,
+        diff_fluxes_mid,
+    )
+
+
+def simpson_integral_values(e1, e2, diff_flux_method):
+    # single energy values given
+    return (
+        (e2 - e1)
+        / 6.0
+        * (
+            diff_flux_method(e1)
+            + 4 * diff_flux_method((e2 + e1) / 2.0)
+            + diff_flux_method(e2)
+        )
+    )
+
+
+def trapz_integral_edges(e_edges, diff_flux_method):
+    ee1 = e_edges[:-1]
+    ee2 = e_edges[1:]
+
+    diff_fluxes_edges = diff_flux_method(e_edges)
+
+    return _trapz(
+        np.array([diff_fluxes_edges[:-1], diff_fluxes_edges[1:]]).T,
+        np.array([ee1, ee2]).T,
+    )
+
+
+def trapz_integral_values(e1, e2, diff_flux_method):
+    # single energy values given
+    return _trapz(
+        np.array([diff_flux_method(e1), diff_flux_method(e2)]),
+        np.array([e1, e2]),
+    )
+
+
+def riemann_integral_edges(e_edges, diff_flux_method):
+    ee1 = e_edges[:-1]
+    ee2 = e_edges[1:]
+
+    e_m = (ee1 + ee2) / 2.0
+
+    # energy width
+    de = ee2 - ee1
+
+    return _rsum(diff_flux_method(e_m), de)
+
+
+def riemann_integral_values(e1, e2, diff_flux_method):
+    return diff_flux_method(0.5 * (e1 + e2)) * (e2 - e1)


### PR DESCRIPTION
> [!NOTE]
> Still a draft - working locally with [astromodels PR 300](https://github.com/threeML/astromodels/pull/300) also with a multiprocessing pool :) 


Adds pocoMC as a sampler (a preconditioned monte carlo sampler) works great for large models like e.g. Fermi/LAT analysis with many free parameters. Easily parallelize-able using either MPI or some shared memory stuff. 

- had to get rid of nested integral_flux and differenital_flux functions in SpectrumLike due to issues when pickling/using multiprocess
- some minor logging/warning stuff
- worked on parallelizing zeus as well 

<!-- readthedocs-preview threeml start -->
----
📚 Documentation preview 📚: https://threeml--688.org.readthedocs.build/en/688/

<!-- readthedocs-preview threeml end -->